### PR TITLE
proper requirements package with the tag updated

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ ujson==1.35
 urllib3==1.10.3
 iso8601>=0.1.11
 lxml>=3.4.4
-git+https://github.com/opentargets/data_model.git@1.2.5#egg=data_model
+git+https://github.com/opentargets/data_model.git@v1.2.5#egg=data_model
 opentargets
 https://cdn.mysql.com/Downloads/Connector-Python/mysql-connector-python-1.0.12.tar.gz
 SPARQLWrapper>=1.7.6


### PR DESCRIPTION
`data_model` was moved to 1.2.5 and tagged to v1.2.5