### PR TITLE
Remove dependency on db

### DIFF
--- a/mrtarget/CommandLine.py
+++ b/mrtarget/CommandLine.py
@@ -152,10 +152,6 @@ def main():
     logger.info('Attempting to establish connection to the backend...')
     db_connected = connectors.init_services_connections(redispersist=args.redispersist)
 
-    if not db_connected and not args.dry_run:
-        msg = 'No connection to the backend could be established. Exiting since this is not a dry run'
-        logger.info(msg)
-        sys.exit(msg)
 
 
     logger.info('setting release version %s' % Config.RELEASE_VERSION)


### PR DESCRIPTION
Some steps (like --dump) do not require an elasticsearch connections so there is no point in exiting the program if ES is not available.
It is plenty of logging lines when trying to connect to ES in case something fails.
close #135 