### PR TITLE
update parameter to avoid division by zero error for eva_somatic & intogen

### DIFF
--- a/mrtarget/modules/EvidenceString.py
+++ b/mrtarget/modules/EvidenceString.py
@@ -807,8 +807,8 @@ class Evidence(JSONSerializable):
             elif self.evidence['type'] == 'somatic_mutation':
                 frequency = 1.
                 if 'known_mutations' in self.evidence['evidence'] and self.evidence['evidence']['known_mutations']:
-                    sample_total_coverage =  0.
-                    max_sample_size = 0.
+                    sample_total_coverage = 1.
+                    max_sample_size = 1.
                     for mutation in self.evidence['evidence']['known_mutations']:
                         if 'number_samples_with_mutation_type' in mutation:
                             sample_total_coverage += int(mutation['number_samples_with_mutation_type'])


### PR DESCRIPTION
@mkarmona this will fix the issue, if not please let me know. thanks!

`2017-06-09 08:07:06,035 - mrtarget.modules.EvidenceString - ERROR - Cannot score evidence 703f7c4f9c28c74f7fa39c8b880720bb of type somatic_mutation. Error: float division by zero`