### PR TITLE
23andme changes , scoring logic update for phewas/23andme and tqdm logging minor bug fix

### DIFF
--- a/mrtarget/Settings.py
+++ b/mrtarget/Settings.py
@@ -345,7 +345,8 @@ class Config():
                                                          cttv025 = 'europepmc',
                                                          cttv005 = 'rare2common',
                                                          cttv010 = 'expression_atlas',
-                                                         cttv026 = 'phewascatalog'
+                                                         cttv026 = 'phewas_catalog',
+                                                         cttv027 = '23andme'
 
                                                 )
 
@@ -363,7 +364,8 @@ class Config():
     DATASOURCE_TO_DATATYPE_MAPPING['uniprot_literature'] = 'genetic_association'
     DATASOURCE_TO_DATATYPE_MAPPING['intogen'] = 'somatic_mutation'
     DATASOURCE_TO_DATATYPE_MAPPING['gene2phenotype'] = 'genetic_association'
-    DATASOURCE_TO_DATATYPE_MAPPING['phewascatalog'] = 'genetic_association'
+    DATASOURCE_TO_DATATYPE_MAPPING['phewas_catalog'] = 'genetic_association'
+    DATASOURCE_TO_DATATYPE_MAPPING['23andme'] = 'genetic_association'
 
     # use specific index for a datasource
     DATASOURCE_TO_INDEX_KEY_MAPPING = defaultdict(lambda: "generic")

--- a/mrtarget/common/ElasticsearchQuery.py
+++ b/mrtarget/common/ElasticsearchQuery.py
@@ -915,8 +915,8 @@ class ESQuery(object):
                     self._flush_bulk(batch)
                     batch = []
 
-            if len(batch) >= chunk_size:
-                self._flush_bulk(batch)
+            #if len(batch) >= chunk_size:
+            self._flush_bulk(batch)
             '''flush changes'''
             self.handler.indices.flush(Loader.get_versioned_index(index,True),
                              wait_if_ongoing=True)

--- a/mrtarget/modules/EvidenceString.py
+++ b/mrtarget/modules/EvidenceString.py
@@ -777,9 +777,9 @@ class Evidence(JSONSerializable):
             elif self.evidence['type'] == 'genetic_association':
                 score=0.
                 if 'gene2variant' in self.evidence['evidence']:
-                    if self.evidence['sourceID'] == 'phewascatalog':
+                    if self.evidence['sourceID'] in ['phewas_catalog','23andme']:
                         no_of_cases = self.evidence['unique_association_fields']['cases']
-                        score = self._score_phewascatalog(
+                        score = self._score_phewas_data(self.evidence['sourceID'],
                             self.evidence['evidence']['variant2disease']['resource_score']['value'],
                             no_of_cases)
 
@@ -912,9 +912,17 @@ class Evidence(JSONSerializable):
         # normalised_pvalue, sample_size,normalised_sample_size, severity))
         return score
 
-    def _score_phewascatalog(self, pvalue, no_of_cases):
-        normalised_pvalue = self._get_score_from_pvalue_linear(float(pvalue), range_min=1, range_max=1e-15)
-        normalised_no_of_cases = DataNormaliser.renormalize(no_of_cases, [0, 5000], [0, 1])
+    def _score_phewas_data(self, source , pvalue, no_of_cases):
+        if source == 'phewas_catalog':
+            max_cases = 8800
+            range_min = 0.05
+            range_max = 1e-25
+        elif source == '23andme':
+            max_cases = 297901
+            range_min = 0.05
+            range_max = 1e-30
+        normalised_pvalue = self._get_score_from_pvalue_linear(float(pvalue), range_min, range_max)
+        normalised_no_of_cases = DataNormaliser.renormalize(no_of_cases, [0, max_cases], [0, 1])
         score = normalised_pvalue * normalised_no_of_cases
         return score
 

--- a/mrtarget/modules/GeneData.py
+++ b/mrtarget/modules/GeneData.py
@@ -724,7 +724,7 @@ class GeneLookUpTable(object):
                                             r_server = self.r_server,
                                             ttl = ttl)
         self._logger = logging.getLogger(__name__)
-        tqdm_out = TqdmToLogger(self._logger,level=logging.INFO)
+        self.tqdm_out = TqdmToLogger(self._logger,level=logging.INFO)
         self.uniprot2ensembl = {}
         if self.r_server and autoload:
             self.load_gene_data(self.r_server, targets)

--- a/mrtarget/modules/HPA.py
+++ b/mrtarget/modules/HPA.py
@@ -415,7 +415,7 @@ class HPALookUpTable(object):
                                              r_server=self.r_server,
                                              ttl=ttl)
         self._logger = logging.getLogger(__name__)
-        tqdm_out = TqdmToLogger(self._logger,level=logging.INFO)
+        self.tqdm_out = TqdmToLogger(self._logger,level=logging.INFO)
 
         if self.r_server:
             self._load_hpa_data(self.r_server)
@@ -426,7 +426,7 @@ class HPALookUpTable(object):
                        unit=' hpa',
                        unit_scale=True,
                        total=self._es_query.count_all_hpa(),
-                       file=tqdm_out,
+                       file=self.tqdm_out,
                        leave=False):
             self.set_hpa(el, r_server=self._get_r_server(r_server))
 


### PR DESCRIPTION
@elipapa @mkarmona  - GeneData and HPA modules were complaining because of the tqdm logger . I have updated them to get rid of the error proceed with phewas processing, but not sure if this is what you intended with the logging changes . Could you please take a look?