### PR TITLE
Implementation of chemicalprobes plugin

### DIFF
--- a/mrtarget/Settings.py
+++ b/mrtarget/Settings.py
@@ -225,6 +225,7 @@ class Config():
 
     HALLMARK_FILENAME = file_or_resource(fname='census_annot.tsv')
     BIOMARKER_FILENAME = file_or_resource(fname='cgi_biomarkers_per_variant.tsv')
+    CHEMICALPROBES_FILENAME = file_or_resource(fname='Chemicalprobes_alldata2.tsv')
 
     TISSUE_TRANSLATION_MAP_URL = 'https://raw.githubusercontent.com/opentargets/expression_hierarchy/master/process/map_with_efos.json'
     TISSUE_CURATION_MAP_URL = 'https://raw.githubusercontent.com/opentargets/expression_hierarchy/master/process/curation.tsv'

--- a/mrtarget/plugins/gene/chemicalprobes.py
+++ b/mrtarget/plugins/gene/chemicalprobes.py
@@ -1,0 +1,76 @@
+from yapsy.IPlugin import IPlugin
+from mrtarget.Settings import Config
+from tqdm import tqdm
+import traceback
+import logging
+logging.basicConfig(level=logging.DEBUG)
+
+class ChemicalProbes(IPlugin):
+
+    # Initiate ChemicalProbes object
+    def __init__(self):
+        self._logger = logging.getLogger(__name__)
+        self.loader = None
+        self.r_server = None
+        self.esquery = None
+        self.ensembl_current = {}
+        self.symbols = {}
+        self.chemicalprobes = {}
+        self.tqdm_out = None
+
+    def print_name(self):
+        self._logger.info("Chemical Probes plugin")
+
+    def merge_data(self, genes, loader, r_server, tqdm_out):
+
+        self.loader = loader
+        self.r_server = r_server
+        self.tqdm_out = tqdm_out
+
+        try:
+            # Parse chemical probes data into self.chemicalprobes
+            self.build_json(filename=Config.CHEMICALPROBES_FILENAME)
+
+            # Iterate through all genes and add chemical probes data if gene symbol is present
+            self._logger.info("Generating Chemical Probes data injection")
+            for gene_id, gene in tqdm(genes.iterate(),
+                                      desc='Adding Chemical Probes data',
+                                      unit=' gene',
+                                      file=self.tqdm_out):
+                # Extend gene with related chemical probe data
+                if gene.approved_symbol in self.chemicalprobes:
+                    self._logger.debug("Adding Chemical Probe data to gene %s", gene.approved_symbol)
+                    gene.chemicalprobes=self.chemicalprobes[gene.approved_symbol]
+
+        except Exception as ex:
+            self._logger.exception(str(ex), exc_info=1)
+            raise ex
+
+    def build_json(self, filename=Config.CHEMICALPROBES_FILENAME):
+
+        with open(filename, 'r') as input:
+            for row in input:
+                (Probe, Target, SGClink, CPPlink, OSPlink, Note) = tuple(row.rstrip().split(';'))
+
+                # If gene has not appeared in chemical probe list yet,
+                # initialise self.chemicalprobes with an empty list
+                if Target not in self.chemicalprobes:
+                    self.chemicalprobes[Target] = []
+
+                # Create list of dictionaries for the links
+                probelinks = []
+                if SGClink != "":
+                    probelinks.append({'source': "Structural Genomics Consortium", 'link': SGClink})
+                if CPPlink != "":
+                    probelinks.append({'source': "Chemical Probes Portal", 'link': CPPlink})
+                if OSPlink != "":
+                    probelinks.append({'source': "Open Science Probes", 'link': OSPlink})
+
+                line = {
+                    "gene": Target,
+                    "chemicalprobe": Probe,
+                    "sourcelinks": probelinks,
+                    "note": Note
+                }
+                # Add data for current chemical probe to self.chemicalprobes
+                self.chemicalprobes[Target].append(line)

--- a/mrtarget/plugins/gene/chemicalprobes.yapsy-plugin
+++ b/mrtarget/plugins/gene/chemicalprobes.yapsy-plugin
@@ -1,0 +1,9 @@
+[Core]
+Name = ChemicalProbes
+Module = chemicalprobes
+
+[Documentation]
+Author = Open Targets Core Team
+Version = 0.1
+Website = http://github.com/opentargets
+Description = Load chemical probe information

--- a/mrtarget/resources/Chemicalprobes_alldata2.tsv
+++ b/mrtarget/resources/Chemicalprobes_alldata2.tsv
@@ -1,0 +1,299 @@
+BAY-850;ATAD2;www.thesgc.org/chemical-probes/BAY-850;;;none
+GSK8814;ATAD2;www.thesgc.org/chemical-probes/GSK8814;;;Protein targets: ATAD2, ATAD2B
+GSK8814;ATAD2B;www.thesgc.org/chemical-probes/GSK8814;;;Protein targets: ATAD2, ATAD2B
+BAZ2-ICR;BAZ2A;www.thesgc.org/chemical-probes/BAZ2-ICR;www.chemicalprobes.org/BAZ2-ICR;;Protein targets: BAZ2A, BAZ2B
+BAZ2-ICR;BAZ2B;www.thesgc.org/chemical-probes/BAZ2-ICR;www.chemicalprobes.org/BAZ2-ICR;;Protein targets: BAZ2A, BAZ2B
+GSK2801;BAZ2A;www.thesgc.org/chemical-probes/GSK2801;;;Protein targets: BAZ2A, BAZ2B
+GSK2801;BAZ2B;www.thesgc.org/chemical-probes/GSK2801;;;Protein targets: BAZ2A, BAZ2B
+BAY-299;BRD1;www.thesgc.org/chemical-probes/BAY-299;;;Protein targets: BRD1, TAF1
+BAY-299;TAF1;www.thesgc.org/chemical-probes/BAY-299;;;Protein targets: BRD1, TAF1
+JQ1;BRD2;www.thesgc.org/chemical-probes/JQ1;www.chemicalprobes.org/JQ1;;Protein targets: BRD2, BRD3, BRD4, BRDT
+JQ1;BRD3;www.thesgc.org/chemical-probes/JQ1;www.chemicalprobes.org/JQ1;;Protein targets: BRD2, BRD3, BRD4, BRDT
+JQ1;BRD4;www.thesgc.org/chemical-probes/JQ1;www.chemicalprobes.org/JQ1;;Protein targets: BRD2, BRD3, BRD4, BRDT
+JQ1;BRDT;www.thesgc.org/chemical-probes/JQ1;www.chemicalprobes.org/JQ1;;Protein targets: BRD2, BRD3, BRD4, BRDT
+PFI-1;BRD2;www.thesgc.org/chemical-probes/PFI-1;www.chemicalprobes.org/PFI-1;;Protein targets: BRD2, BRD3, BRD4, BRDT
+PFI-1;BRD3;www.thesgc.org/chemical-probes/PFI-1;www.chemicalprobes.org/PFI-1;;Protein targets: BRD2, BRD3, BRD4, BRDT
+PFI-1;BRD4;www.thesgc.org/chemical-probes/PFI-1;www.chemicalprobes.org/PFI-1;;Protein targets: BRD2, BRD3, BRD4, BRDT
+PFI-1;BRDT;www.thesgc.org/chemical-probes/PFI-1;www.chemicalprobes.org/PFI-1;;Protein targets: BRD2, BRD3, BRD4, BRDT
+I-BRD9;BRD9;www.thesgc.org/chemical-probes/I-BRD9;www.chemicalprobes.org/I-BRD9;;none
+BI-9564;BRD9;www.thesgc.org/chemical-probes/BI-9564;www.chemicalprobes.org/BI-9564;;Protein targets: BRD9, BRD7
+BI-9564;BRD7;www.thesgc.org/chemical-probes/BI-9564;www.chemicalprobes.org/BI-9564;;Protein targets: BRD9, BRD7
+LP99;BRD9;www.thesgc.org/chemical-probes/LP99;;;Protein targets: BRD9, BRD7
+LP99;BRD7;www.thesgc.org/chemical-probes/LP99;;;Protein targets: BRD9, BRD7
+TP-472;BRD9;www.thesgc.org/chemical-probes/TP-472;;;Protein targets: BRD9, BRD7
+TP-472;BRD7;www.thesgc.org/chemical-probes/TP-472;;;Protein targets: BRD9, BRD7
+GSK6853;BRPF1;www.thesgc.org/chemical-probes/GSK6853;;;none
+NI-57;BRPF1;www.thesgc.org/chemical-probes/NI-57;;;Protein targets: BRPF1, BRPF2, BRPF3
+NI-57;BRPF2;www.thesgc.org/chemical-probes/NI-57;;;Protein targets: BRPF1, BRPF2, BRPF3
+NI-57;BRPF3;www.thesgc.org/chemical-probes/NI-57;;;Protein targets: BRPF1, BRPF2, BRPF3
+OF-1;BRPF1;www.thesgc.org/chemical-probes/OF-1;;;Protein targets: BRPF1, BRPF2, BRPF3
+OF-1;BRPF2;www.thesgc.org/chemical-probes/OF-1;;;Protein targets: BRPF1, BRPF2, BRPF3
+OF-1;BRPF3;www.thesgc.org/chemical-probes/OF-1;;;Protein targets: BRPF1, BRPF2, BRPF3
+PFI-4;BRPF1;www.thesgc.org/chemical-probes/PFI-4;;;BRPF1 has two isoforms BRPF1A & BRPF1B, only BRPF1B is bound
+NVS-CECR2-1;CECR2;www.thesgc.org/chemical-probes/NVS-CECR2-1;;;none
+I-CBP112;CREBBP;www.thesgc.org/chemical-probes/I-CBP112;www.chemicalprobes.org/I-CBP112;;Protein targets: CREBBP, EP300
+I-CBP112;EP300;www.thesgc.org/chemical-probes/I-CBP112;www.chemicalprobes.org/I-CBP112;;Protein targets: CREBBP, EP300
+SGC-CBP30;CREBBP;www.thesgc.org/chemical-probes/SGC-CBP30;www.chemicalprobes.org/SGC-CBP30;;Protein targets: CREBBP, EP300
+SGC-CBP30;EP300;www.thesgc.org/chemical-probes/SGC-CBP30;www.chemicalprobes.org/SGC-CBP30;;Protein targets: CREBBP, EP300
+SGC0946;DOT1L;www.thesgc.org/chemical-probes/SGC0946;www.chemicalprobes.org/SGC0946;;none
+A-395;EED;www.thesgc.org/chemical-probes/A-395;www.chemicalprobes.org/395;;none
+GSK343;EZH2;www.thesgc.org/chemical-probes/GSK343;www.chemicalprobes.org/GSK343;;none
+UNC1999;EZH1;www.thesgc.org/chemical-probes/UNC1999;www.chemicalprobes.org/UNC1999;;Protein targets: EZH1, EZH2
+UNC1999;EZH2;www.thesgc.org/chemical-probes/UNC1999;www.chemicalprobes.org/UNC1999;;Protein targets: EZH1, EZH2
+A-366;EHMT2;www.thesgc.org/chemical-probes/A-366;www.chemicalprobes.org/A-366;;Protein targets: EHMT2, EHMT1
+A-366;EHMT1;www.thesgc.org/chemical-probes/A-366;www.chemicalprobes.org/A-366;;Protein targets: EHMT2, EHMT1
+UNC0638;EHMT2;www.thesgc.org/chemical-probes/UNC0638;;;Protein targets: EHMT2, EHMT1
+UNC0638;EHMT1;www.thesgc.org/chemical-probes/UNC0638;;;Protein targets: EHMT2, EHMT1
+UNC0642;EHMT2;www.thesgc.org/chemical-probes/UNC0642;www.chemicalprobes.org/UNC0642;;Protein targets: EHMT2, EHMT1
+UNC0642;EHMT1;www.thesgc.org/chemical-probes/UNC0642;www.chemicalprobes.org/UNC0642;;Protein targets: EHMT2, EHMT1
+BAY-876;SLC2A1;www.thesgc.org/chemical-probes/BAY-876;;;none
+FM-381;JAK3;www.thesgc.org/chemical-probes/FM-381;www.chemicalprobes.org/FM-381;;none
+GSK-J1;KDM6B;www.thesgc.org/chemical-probes/GSK-J1;;;Protein targets: KDM6B, KDM6A, KDM5B
+GSK-J1;KDM6A;www.thesgc.org/chemical-probes/GSK-J1;;;Protein targets: KDM6B, KDM6A, KDM5B
+GSK-J1;KDM5B;www.thesgc.org/chemical-probes/GSK-J1;;;Protein targets: KDM6B, KDM6A, KDM5B
+UNC1215;L3MBTL3;www.thesgc.org/chemical-probes/UNC1215;www.chemicalprobes.org/UNC1215;;none
+TH-257;LIMK1;www.thesgc.org/chemical-probes/TH-257;;;Protein targets: LIMK1, LIMK2
+TH-257;LIMK2;www.thesgc.org/chemical-probes/TH-257;;;Protein targets: LIMK1, LIMK2
+GSK-LSD1;KDM1A;www.thesgc.org/chemical-probes/GSK-LSD1;;;none
+T-26c;MMP13;www.thesgc.org/chemical-probes/T-26c;;;none
+GSK864;IDH1;www.thesgc.org/chemical-probes/GSK864;www.chemicalprobes.org/GSK864;;IDH1 mutants R132C/R132H/R132G
+BAY-678;ELANE;www.thesgc.org/chemical-probes/BAY-678;;;none
+A-485;CREBBP;www.thesgc.org/chemical-probes/A-485;;http://www.sgc-ffm.uni-frankfurt.de/#!specificprobeoverview/A-485;Protein targets: CREBBP, EP300
+A-485;EP300;www.thesgc.org/chemical-probes/A-485;;http://www.sgc-ffm.uni-frankfurt.de/#!specificprobeoverview/A-485;Protein targets: CREBBP, EP300
+GSK484;PADI4;www.thesgc.org/chemical-probes/GSK484;www.chemicalprobes.org/GSK484;;none
+NVS-PAK1-1;PAK1;www.thesgc.org/chemical-probes/NVS-PAK1-1;www.chemicalprobes.org/NVS-PAK1-1;;none
+IOX1;pan-2-OG;www.thesgc.org/chemical-probes/IOX1;;;Tool compound
+Bromosporine;pan-Bromodomain;www.thesgc.org/chemical-probes/Bromosporine;;;Tool compound
+GSK4027;KAT2B;www.thesgc.org/chemical-probes/GSK4027;;;Protein targets: PCAF, GCN5
+GSK4027;GCN5;www.thesgc.org/chemical-probes/GSK4027;www.chemicalprobes.org/GSK4027;;Protein targets: PCAF, GCN5
+L-Moses;KAT2B;www.thesgc.org/chemical-probes/L-Moses;;;Protein targets: PCAF, GCN5
+L-Moses;GCN5;www.thesgc.org/chemical-probes/L-Moses;;;Protein targets: PCAF, GCN5
+IOX2;EGLN1;www.thesgc.org/chemical-probes/IOX2;;;none
+SGC707;PRMT3;www.thesgc.org/chemical-probes/SGC707;www.chemicalprobes.org/SGC707;;none
+SKI-73;CARM1;www.thesgc.org/chemical-probes/SKI-73;;;none
+TP-064;CARM1;www.thesgc.org/chemical-probes/TP-064;;;none
+MS049;CARM1;www.thesgc.org/chemical-probes/MS049;;;Protein targets: CARM1, PRMT6
+MS049;PRMT6;www.thesgc.org/chemical-probes/MS049;;;Protein targets: CARM1, PRMT6
+GSK591;PRMT5;www.thesgc.org/chemical-probes/GSK591;www.chemicalprobes.org/GSK591;;none
+LLY-283;PRMT5;www.thesgc.org/chemical-probes/LLY-283;;;none
+PFI-2;SETD7;www.thesgc.org/chemical-probes/PFI-2;;;none
+BI01383298;SLC13A5;www.thesgc.org/chemical-probes/BI01383298;;;none
+PFI-3;SMARCA2;www.thesgc.org/chemical-probes/PFI-3;;;Protein targets: SMARCA2, SMARCA4, PBRM1
+PFI-3;SMARCA4;www.thesgc.org/chemical-probes/PFI-3;;;Protein targets: SMARCA2, SMARCA4, PBRM1
+PFI-3;PBRM1;www.thesgc.org/chemical-probes/PFI-3;;;Protein targets: SMARCA2, SMARCA4, PBRM1
+BAY-598;SMYD2;www.thesgc.org/chemical-probes/BAY-598;www.chemicalprobes.org/BAY-598;;none
+LLY-507;SMYD2;www.thesgc.org/chemical-probes/LLY-507;;;none
+PFI-5;SMYD2;www.thesgc.org/chemical-probes/PFI-5;;;none
+BAY-6035;SMYD3;www.thesgc.org/chemical-probes/BAY-6035;;;none
+A-196;KMT5B;www.thesgc.org/chemical-probes/A-196;www.chemicalprobes.org/A-196;;Protein targets: KMT5B, KMT5C
+A-196;KMT5C;www.thesgc.org/chemical-probes/A-196;www.chemicalprobes.org/A-196;;Protein targets: KMT5B, KMT5C
+MS023;PRMT1;www.thesgc.org/chemical-probes/MS023;www.chemicalprobes.org/MS023;;Protein targets are Type I PRMTs: PRMT1, PRMT3, CARM1 (=PRMT4), PRMT6, PRMT8
+MS023;PRMT3;www.thesgc.org/chemical-probes/MS023;www.chemicalprobes.org/MS023;;Protein targets are Type I PRMTs: PRMT1, PRMT3, CARM1 (=PRMT4), PRMT6, PRMT8
+MS023;CARM1;www.thesgc.org/chemical-probes/MS023;;;Protein targets are Type I PRMTs: PRMT1, PRMT3, CARM1 (=PRMT4), PRMT6, PRMT8
+MS023;PRMT6;www.thesgc.org/chemical-probes/MS023;www.chemicalprobes.org/MS023;;Protein targets are Type I PRMTs: PRMT1, PRMT3, CARM1 (=PRMT4), PRMT6, PRMT8
+MS023;PRMT8;www.thesgc.org/chemical-probes/MS023;www.chemicalprobes.org/MS023;;Protein targets are Type I PRMTs: PRMT1, PRMT3, CARM1 (=PRMT4), PRMT6, PRMT8
+OICR-9429;WDR5;www.thesgc.org/chemical-probes/OICR-9429;www.chemicalprobes.org/OICR-9429;;none
+A-1155463;BCL2L1;;www.chemicalprobes.org/1155463;;none
+WEHI-539;BCL2L1;;www.chemicalprobes.org/WEHI-539;;none
+BMX-IN-1;BMX;;www.chemicalprobes.org/BMX-IN-1;;none
+KH-CB19;CLK1;;www.chemicalprobes.org/KH-CB19;;Protein targets: CLK1, CLK4, DYRK1A
+KH-CB19;CLK4;;www.chemicalprobes.org/KH-CB19;;Protein targets: CLK1, CLK4, DYRK1A
+KH-CB19;DYRK1A;;www.chemicalprobes.org/KH-CB19;;Protein targets: CLK1, CLK4, DYRK1A
+AZ191;DYRK1B;;www.chemicalprobes.org/AZ191;;none
+RGFP966;HDAC3;;www.chemicalprobes.org/RGFP966;;none
+ACY-738;HDAC6;;www.chemicalprobes.org/ACY-738;;none
+GSK-J4;KDM6A;;www.chemicalprobes.org/GSK-J4;;Protein targets: KDM6A, KDM6B
+GSK-J4;KDM6B;;www.chemicalprobes.org/GSK-J4;;Protein targets: KDM6A, KDM6B
+KI-696;KEAP1;;www.chemicalprobes.org/KI-696;;none
+GNE7915;LRRK2;;www.chemicalprobes.org/GNE7915;;none
+GW3965;NR1H2;;www.chemicalprobes.org/GW3965;;Protein targets: NR1H2, NR1H3
+GW3965;NR1H3;;www.chemicalprobes.org/GW3965;;Protein targets: NR1H2, NR1H3
+BIX-02188;MAP2K5;;www.chemicalprobes.org/BIX-02188;;none
+MI-888;MDM2;;www.chemicalprobes.org/MI-888;;none
+RG7112;MDM2;;www.chemicalprobes.org/RG7112;;none
+UNC2025;MERTK;;www.chemicalprobes.org/UNC2025;;Protein targets: MERTK, FLT3
+UNC2025;FLT3;;www.chemicalprobes.org/UNC2025;;Protein targets: MERTK, FLT3
+eCF309;MTOR;;www.chemicalprobes.org/eCF309;;none
+Pevonedistat;UBA3;;www.chemicalprobes.org/Pevonedistat;;none
+WZ4003;NUAK1;;www.chemicalprobes.org/WZ4003;;Protein targets: NUAK1, NUAK2
+WZ4003;NUAK2;;www.chemicalprobes.org/WZ4003;;Protein targets: NUAK1, NUAK2
+Salvinorin A;OPRK1;;www.chemicalprobes.org/Salvinorin;;none
+PF-3758309;PAK1;;www.chemicalprobes.org/PF-3758309;;Protein targets: PAK1, PAK4, PAK5, PAK6
+PF-3758309;PAK4;;www.chemicalprobes.org/PF-3758309;;Protein targets: PAK1, PAK4, PAK5, PAK6
+PF-3758309;PAK5;;www.chemicalprobes.org/PF-3758309;;Protein targets: PAK1, PAK4, PAK5, PAK6
+PF-3758309;PAK6;;www.chemicalprobes.org/PF-3758309;;Protein targets: PAK1, PAK4, PAK5, PAK6
+E7449;PARP1;;www.chemicalprobes.org/E7449;;Protein targets: PARP1, PARP2, TNKS, TNKS2
+E7449;PARP2;;www.chemicalprobes.org/E7449;;Protein targets: PARP1, PARP2, TNKS, TNKS2
+E7449;TNKS;;www.chemicalprobes.org/E7449;;Protein targets: PARP1, PARP2, TNKS, TNKS2
+E7449;TNKS2;;www.chemicalprobes.org/E7449;;Protein targets: PARP1, PARP2, TNKS, TNKS2
+Olaparib;PARP1;;www.chemicalprobes.org/Olaparib;;Protein targets: PARP1, PARP2
+Olaparib;PARP2;;www.chemicalprobes.org/Olaparib;;Protein targets: PARP1, PARP2
+Cotransin;SEC61A1;;www.chemicalprobes.org/Cotransin;;SEC61 complex (SEC61A1, SEC61A2, SEC61B, SEC61G), precise interactions have not been identified
+Cotransin;SEC61A2;;www.chemicalprobes.org/Cotransin;;SEC61 complex (SEC61A1, SEC61A2, SEC61B, SEC61G), precise interactions have not been identified
+Cotransin;SEC61B;;www.chemicalprobes.org/Cotransin;;SEC61 complex (SEC61A1, SEC61A2, SEC61B, SEC61G), precise interactions have not been identified
+Cotransin;SEC61G;;www.chemicalprobes.org/Cotransin;;SEC61 complex (SEC61A1, SEC61A2, SEC61B, SEC61G), precise interactions have not been identified
+HG-9-91-01;SIK1;;www.chemicalprobes.org/HG-9-91-01;;Protein targets: SIK1, SIK2, SIK3
+HG-9-91-01;SIK2;;www.chemicalprobes.org/HG-9-91-01;;Protein targets: SIK1, SIK2, SIK3
+HG-9-91-01;SIK3;;www.chemicalprobes.org/HG-9-91-01;;Protein targets: SIK1, SIK2, SIK3
+eCF506;SRC;;www.chemicalprobes.org/eCF506;;none
+AZ6102;TNKS;;www.chemicalprobes.org/AZ6102;;Protein targets: TNKS, TNKS2
+AZ6102;TNKS2;;www.chemicalprobes.org/AZ6102;;Protein targets: TNKS, TNKS2
+BiBET;BRD4;;www.chemicalprobes.org/BiBET;;Protein targets: BRD4, BRD3, BRD2, BRDT
+BiBET;BRD3;;www.chemicalprobes.org/BiBET;;Protein targets: BRD4, BRD3, BRD2, BRDT
+BiBET;BRD2;;www.chemicalprobes.org/BiBET;;Protein targets: BRD4, BRD3, BRD2, BRDT
+BiBET;BRDT;;www.chemicalprobes.org/BiBET;;Protein targets: BRD4, BRD3, BRD2, BRDT
+THZ1;CDK7;;www.chemicalprobes.org/THZ1;;none
+CCT244747;CHEK1;;www.chemicalprobes.org/CCT244747;;none
+AMG-18;ERN1;;www.chemicalprobes.org/AMG-18;;none
+EPZ-6438;EZH2;;www.chemicalprobes.org/EPZ-6438;;none
+AC220;FLT3;;www.chemicalprobes.org/AC220;;none
+Tubacin;HDAC6;;www.chemicalprobes.org/Tubacin;;none
+NVP-AEW541;IGF1R;;www.chemicalprobes.org/NVP-AEW541;;none
+Filgotinib;JAK1;;www.chemicalprobes.org/Filgotinib;;none
+Selumetinib;MAP2K1;;www.chemicalprobes.org/Selumetinib;;none
+JNK-IN-8;MAPK8;;www.chemicalprobes.org/JNK-IN-8;;Protein targets: MAPK8, MAPK9, MAPK10
+JNK-IN-8;MAPK9;;www.chemicalprobes.org/JNK-IN-8;;Protein targets: MAPK8, MAPK9, MAPK10
+JNK-IN-8;MAPK10;;www.chemicalprobes.org/JNK-IN-8;;Protein targets: MAPK8, MAPK9, MAPK10
+PF3644022;MAPKAPK2;;www.chemicalprobes.org/PF3644022;;none
+Rapamycin;MTOR;;www.chemicalprobes.org/Rapamycin;;none
+PDD00017273;PARG;;www.chemicalprobes.org/PDD00017273;;none
+Talazoparib;PARP1;;www.chemicalprobes.org/Talazoparib;;Protein targets: PARP1, PARP2
+Talazoparib;PARP2;;www.chemicalprobes.org/Talazoparib;;Protein targets: PARP1, PARP2
+ML323;USP1;;www.chemicalprobes.org/ML323;;Protein targets: USP1, WDR48
+ML323;WDR48;;www.chemicalprobes.org/ML323;;Protein targets: USP1, WDR48
+GNF-5;ABL1;;www.chemicalprobes.org/GNF-5;;Protein targets: ABL1, ABL2, BCR-APL fusion protein
+GNF-5;ABL2;;www.chemicalprobes.org/GNF-5;;Protein targets: ABL1, ABL2, BCR-APL fusion protein
+MZ1;BRD4;;www.chemicalprobes.org/MZ1;;none
+AMG900;AURKA;;www.chemicalprobes.org/AMG900;;Protein targets: AURKA, AURKB, AURKC
+AMG900;AURKB;;www.chemicalprobes.org/AMG900;;Protein targets: AURKA, AURKB, AURKC
+AMG900;AURKC;;www.chemicalprobes.org/AMG900;;Protein targets: AURKA, AURKB, AURKC
+AZD1152;AURKB;;www.chemicalprobes.org/AZD1152;;none
+GDC-0879;BRAF V600E;;www.chemicalprobes.org/GDC-0879;;BRAF Mutant V600E
+PF-477736;CHEK1;;www.chemicalprobes.org/PF-477736;;none
+CCT241533;CHEK2;;www.chemicalprobes.org/CCT241533;;none
+PF-CBP1;CREBBP;;www.chemicalprobes.org/PF-CBP1;;none
+EPZ-5676;DOT1L;;www.chemicalprobes.org/EPZ-5676;;none
+EPZ011989;EZH1;;www.chemicalprobes.org/EPZ011989;;Protein targets: EZH1, EZH2
+EPZ011989;EZH2;;www.chemicalprobes.org/EPZ011989;;Protein targets: EZH1, EZH2
+EI1;EZH2;;www.chemicalprobes.org/EI1;;none
+BGJ-398;FGFR1;;www.chemicalprobes.org/BGJ-398;;Protein targets: FGFR1, FGFR2, FGFR3, FGFR4
+BGJ-398;FGFR2;;www.chemicalprobes.org/BGJ-398;;Protein targets: FGFR1, FGFR2, FGFR3, FGFR4
+BGJ-398;FGFR3;;www.chemicalprobes.org/BGJ-398;;Protein targets: FGFR1, FGFR2, FGFR3, FGFR4
+BGJ-398;FGFR4;;www.chemicalprobes.org/BGJ-398;;Protein targets: FGFR1, FGFR2, FGFR3, FGFR4
+BLU9931;FGFR4;;www.chemicalprobes.org/BLU9931;;none
+CHIR-99021;GSK3A;;www.chemicalprobes.org/CHIR-99021;;Protein targets: GSK3A, GSK3B
+CHIR-99021;GSK3B;;www.chemicalprobes.org/CHIR-99021;;Protein targets: GSK3A, GSK3B
+Romidepsin;HDAC1;;www.chemicalprobes.org/Romidepsin;;Protein targets: HDAC1, HDAC2, HDAC3, HDAC8
+Romidepsin;HDAC2;;www.chemicalprobes.org/Romidepsin;;Protein targets: HDAC1, HDAC2, HDAC3, HDAC8
+Romidepsin;HDAC3;;www.chemicalprobes.org/Romidepsin;;Protein targets: HDAC1, HDAC2, HDAC3, HDAC8
+Romidepsin;HDAC8;;www.chemicalprobes.org/Romidepsin;;Protein targets: HDAC1, HDAC2, HDAC3, HDAC8
+Tofacitinib;JAK1;;www.chemicalprobes.org/Tofacitinib;;Protein targets: JAK1, JAK2, JAK3
+Tofacitinib;JAK2;;www.chemicalprobes.org/Tofacitinib;;Protein targets: JAK1, JAK2, JAK3
+Tofacitinib;JAK3;;www.chemicalprobes.org/Tofacitinib;;Protein targets: JAK1, JAK2, JAK3
+BMS-911543;JAK2;;www.chemicalprobes.org/BMS-911543;;none
+Skepinone-L;MAPK14;;www.chemicalprobes.org/Skepinone-L;;none
+SGX-523;MET;;www.chemicalprobes.org/SGX-523;;none
+AZD2014;MTOR;;www.chemicalprobes.org/AZD2014;;none
+G-5555;PAK1;;www.chemicalprobes.org/G-5555;;Protein targets: PAK1, PAK2, PAK3
+G-5555;PAK2;;www.chemicalprobes.org/G-5555;;Protein targets: PAK1, PAK2, PAK3
+G-5555;PAK3;;www.chemicalprobes.org/G-5555;;Protein targets: PAK1, PAK2, PAK3
+KZR-504;PSMB9;;www.chemicalprobes.org/KZR-504;;none
+GSK583;RIPK2;;www.chemicalprobes.org/GSK583;;none
+P505-15;SYK;;www.chemicalprobes.org/P505-15;;none
+VH298;VHL;;www.chemicalprobes.org/VH298;;none
+EED226;EED;;www.chemicalprobes.org/EED226;;none
+GSK4027;PCAF;;www.chemicalprobes.org/GSK4027;;Protein targets: PCAF, GCN5
+CH5424802;ALK;;www.chemicalprobes.org/CH5424802;;none
+MK-5108;AURKA;;www.chemicalprobes.org/MK-5108;;none
+Venetoclax;BCL2;;www.chemicalprobes.org/Venetoclax;;none
+Taxol;TUBB;;www.chemicalprobes.org/Taxol;;beta tubulin, precise interactions have not been identified
+Taxol;TUBB1;;www.chemicalprobes.org/Taxol;;beta tubulin, precise interactions have not been identified
+Taxol;TUBB2A;;www.chemicalprobes.org/Taxol;;beta tubulin, precise interactions have not been identified
+Taxol;TUBB2B;;www.chemicalprobes.org/Taxol;;beta tubulin, precise interactions have not been identified
+Taxol;TUBB3;;www.chemicalprobes.org/Taxol;;beta tubulin, precise interactions have not been identified
+Taxol;TUBB4A;;www.chemicalprobes.org/Taxol;;beta tubulin, precise interactions have not been identified
+Taxol;TUBB4B;;www.chemicalprobes.org/Taxol;;beta tubulin, precise interactions have not been identified
+Taxol;TUBB6;;www.chemicalprobes.org/Taxol;;beta tubulin, precise interactions have not been identified
+Taxol;TUBB8;;www.chemicalprobes.org/Taxol;;beta tubulin, precise interactions have not been identified
+CPI-0610;BRD2;;www.chemicalprobes.org/CPI-0610;;Protein targets: BRD2, BRD3, BRD4, BRDT
+CPI-0610;BRD3;;www.chemicalprobes.org/CPI-0610;;Protein targets: BRD2, BRD3, BRD4, BRDT
+CPI-0610;BRD4;;www.chemicalprobes.org/CPI-0610;;Protein targets: BRD2, BRD3, BRD4, BRDT
+CPI-0610;BRDT;;www.chemicalprobes.org/CPI-0610;;Protein targets: BRD2, BRD3, BRD4, BRDT
+MT1;BRD2;;www.chemicalprobes.org/MT1;;Protein targets: BRD2, BRD3, BRD4, BRDT
+MT1;BRD3;;www.chemicalprobes.org/MT1;;Protein targets: BRD2, BRD3, BRD4, BRDT
+MT1;BRD4;;www.chemicalprobes.org/MT1;;Protein targets: BRD2, BRD3, BRD4, BRDT
+MT1;BRDT;;www.chemicalprobes.org/MT1;;Protein targets: BRD2, BRD3, BRD4, BRDT
+CGI1746;BTK;;www.chemicalprobes.org/CGI1746;;none
+PD0332991;CDK4;;www.chemicalprobes.org/PD0332991;;Protein targets: CDK4, CDK6
+PD0332991;CDK6;;www.chemicalprobes.org/PD0332991;;Protein targets: CDK4, CDK6
+CCT251545;CDK8;;www.chemicalprobes.org/CCT251545;;Protein targets: CDK8, CDK19
+CCT251545;CDK19;;www.chemicalprobes.org/CCT251545;;Protein targets: CDK8, CDK19
+EPZ004777;DOT1L;;www.chemicalprobes.org/EPZ004777;;none
+CP-724714;ERBB2;;www.chemicalprobes.org/CP-724714;;none
+CPI-169;EZH1;;www.chemicalprobes.org/CPI-169;;Protein targets: EZH1, EZH2
+CPI-169;EZH2;;www.chemicalprobes.org/CPI-169;;Protein targets: EZH1, EZH2
+CPI-360;EZH2;;www.chemicalprobes.org/CPI-360;;none
+Linsitinib;IGF1R;;www.chemicalprobes.org/Linsitinib;;Protein targets: IGF1R, INSR, INSRR
+Linsitinib;INSR;;www.chemicalprobes.org/Linsitinib;;Protein targets: IGF1R, INSR, INSRR
+Linsitinib;INSRR;;www.chemicalprobes.org/Linsitinib;;Protein targets: IGF1R, INSR, INSRR
+Ruxolitinib;JAK1;;www.chemicalprobes.org/Ruxolitinib;;Protein targets: JAK1, JAK2
+Ruxolitinib;JAK2;;www.chemicalprobes.org/Ruxolitinib;;Protein targets: JAK1, JAK2
+SCH772984;MAPK1;;www.chemicalprobes.org/SCH772984;;Protein targets: MAPK1, MAPK3
+SCH772984;MAPK3;;www.chemicalprobes.org/SCH772984;;Protein targets: MAPK1, MAPK3
+VX-745;MAPK14;;www.chemicalprobes.org/VX-745;;none
+AX15836;MAPK7;;www.chemicalprobes.org/AX15836;;none
+S63845;MCL1;;www.chemicalprobes.org/S63845;;none
+AM-6761;MDM2;;www.chemicalprobes.org/AM-6761;;none
+AMG232;MDM2;;www.chemicalprobes.org/AMG232;;none
+MI-77301;MDM2;;www.chemicalprobes.org/MI-77301;;none
+RG7388;MDM2;;www.chemicalprobes.org/RG7388;;none
+RO5353;MDM2;;www.chemicalprobes.org/RO5353;;none
+Niraparib;PARP1;;www.chemicalprobes.org/Niraparib;;Protein targets: PARP1, PARP2
+Niraparib;PARP2;;www.chemicalprobes.org/Niraparib;;Protein targets: PARP1, PARP2
+Veliparib;PARP1;;www.chemicalprobes.org/Veliparib;;Protein targets: PARP1, PARP2
+Veliparib;PARP2;;www.chemicalprobes.org/Veliparib;;Protein targets: PARP1, PARP2
+GSK2334470;PDK1;;www.chemicalprobes.org/GSK2334470;;none
+BYL-719;PIK3CA;;www.chemicalprobes.org/BYL-719;;none
+CCT251236;PIR;;www.chemicalprobes.org/CCT251236;;none
+MS023;PRMT4;;www.chemicalprobes.org/MS023;;Protein targets: PRMT1, PRMT3, PRMT4, PRMT6, PRMT8
+EPZ015666;PRMT5;;www.chemicalprobes.org/EPZ015666;;none
+GSK481;RIPK1;;www.chemicalprobes.org/GSK481;;none
+(R)-PFI-2;SETD7;;www.chemicalprobes.org/R-PFI-2;;none
+GSM1;APH1A;;;http://www.sgc-ffm.uni-frankfurt.de/#!specificprobeoverview/GSM1;gamma secretase complex, precise interactions have not been identified
+GSM1;APH1B;;;http://www.sgc-ffm.uni-frankfurt.de/#!specificprobeoverview/GSM1;gamma secretase complex, precise interactions have not been identified
+GSM1;PSEN1;;;http://www.sgc-ffm.uni-frankfurt.de/#!specificprobeoverview/GSM1;gamma secretase complex, precise interactions have not been identified
+GSM1;NCSTN;;;http://www.sgc-ffm.uni-frankfurt.de/#!specificprobeoverview/GSM1;gamma secretase complex, precise interactions have not been identified
+GSM1;PSENEN;;;http://www.sgc-ffm.uni-frankfurt.de/#!specificprobeoverview/GSM1;gamma secretase complex, precise interactions have not been identified
+PF-05105679;TRPM8;;;http://www.sgc-ffm.uni-frankfurt.de/#!specificprobeoverview/PF-05105679;none
+PF-04457845;FAAH;;;http://www.sgc-ffm.uni-frankfurt.de/#!specificprobeoverview/PF-04457845;none
+PF-04418948;PTGER2;;;http://www.sgc-ffm.uni-frankfurt.de/#!specificprobeoverview/PF-04418948;none
+MRL-SYKi;SYK;;;http://www.sgc-ffm.uni-frankfurt.de/#!specificprobeoverview/MRL-SYKi;none
+MRL-650;CNR1;;;http://www.sgc-ffm.uni-frankfurt.de/#!specificprobeoverview/MRL-650;none
+MRK-560;APH1A;;;http://www.sgc-ffm.uni-frankfurt.de/#!specificprobeoverview/MRK-560;gamma secretase complex, precise interactions have not been identified
+MRK-560;APH1B;;;http://www.sgc-ffm.uni-frankfurt.de/#!specificprobeoverview/MRK-560;gamma secretase complex, precise interactions have not been identified
+MRK-560;PSEN1;;;http://www.sgc-ffm.uni-frankfurt.de/#!specificprobeoverview/MRK-560;gamma secretase complex, precise interactions have not been identified
+MRK-560;NCSTN;;;http://www.sgc-ffm.uni-frankfurt.de/#!specificprobeoverview/MRK-560;gamma secretase complex, precise interactions have not been identified
+MRK-560;PSENEN;;;http://www.sgc-ffm.uni-frankfurt.de/#!specificprobeoverview/MRK-560;gamma secretase complex, precise interactions have not been identified
+ERKi;MAPK3;;;http://www.sgc-ffm.uni-frankfurt.de/#!specificprobeoverview/ERKi;Protein targts: MAPK3, MAPK1
+ERKi;MAPK1;;;http://www.sgc-ffm.uni-frankfurt.de/#!specificprobeoverview/ERKi;Protein targts: MAPK3, MAPK1
+CRTH2 antagonist;PTGDR2;;;http://www.sgc-ffm.uni-frankfurt.de/#!specificprobeoverview/CRTH%3Csub%3E2%3C/sub%3E%20antagonist;none
+ABT-100;FNTB;;;http://www.sgc-ffm.uni-frankfurt.de/#!specificprobeoverview/ABT-100;none
+ABT-546;EDNRA;;;http://www.sgc-ffm.uni-frankfurt.de/#!specificprobeoverview/ABT-546;none
+BAY-826;TIE1;;;http://www.sgc-ffm.uni-frankfurt.de/#!specificprobeoverview/BAY-826;Protein targets: TIE1, TEK, DDR1, DDR2
+BAY-826;TEK;;;http://www.sgc-ffm.uni-frankfurt.de/#!specificprobeoverview/BAY-826;Protein targets: TIE1, TEK, DDR1, DDR2
+BAY-826;DDR1;;;http://www.sgc-ffm.uni-frankfurt.de/#!specificprobeoverview/BAY-826;Protein targets: TIE1, TEK, DDR1, DDR2
+BAY-826;DDR2;;;http://www.sgc-ffm.uni-frankfurt.de/#!specificprobeoverview/BAY-826;Protein targets: TIE1, TEK, DDR1, DDR2
+PF-04554878;PTK2;;;http://www.sgc-ffm.uni-frankfurt.de/#!specificprobeoverview/PF-04554878;Protein targets: PTK2, PTK2B
+PF-04554878;PTK2B;;;http://www.sgc-ffm.uni-frankfurt.de/#!specificprobeoverview/PF-04554878;Protein targets: PTK2, PTK2B
+ABT-724;DRD4;;;http://www.sgc-ffm.uni-frankfurt.de/#!specificprobeoverview/ABT-724;none
+BI 99179;FASN;;;http://www.sgc-ffm.uni-frankfurt.de/#!specificprobeoverview/BI%2099179;none
+TP-004;METAP2;;;http://www.sgc-ffm.uni-frankfurt.de/#!specificprobeoverview/TP-004;none
+BI-9627;SLC9A1;;;http://www.sgc-ffm.uni-frankfurt.de/#!specificprobeoverview/BI-9627;none
+BI 665915;ALOX5AP;;;http://www.sgc-ffm.uni-frankfurt.de/#!specificprobeoverview/BI%20665915;none
+BI-1935;EPHX2;;;http://www.sgc-ffm.uni-frankfurt.de/#!specificprobeoverview/BI-1935;none
+BAY-386;F2R;;;http://www.sgc-ffm.uni-frankfurt.de/#!specificprobeoverview/BAY-386;none
+BAY-7598;MMP12;;;http://www.sgc-ffm.uni-frankfurt.de/#!specificprobeoverview/BAY-7598;none
+KISS1-305;KISS1R;;;http://www.sgc-ffm.uni-frankfurt.de/#!specificprobeoverview/KISS1-305;none
+BAY-707;NUDT1;;;http://www.sgc-ffm.uni-frankfurt.de/#!specificprobeoverview/BAY-707;none
+BAY-474;MET;;;http://www.sgc-ffm.uni-frankfurt.de/#!specificprobeoverview/BAY-474;none
+(R)-9s;ADRA1D;;;http://www.sgc-ffm.uni-frankfurt.de/#!specificprobeoverview/(R)-9s;none


### PR DESCRIPTION
Injection of Chemical Probe info into Gene Index. 

Chemical probes from 3 sources:
1) Structural Genomics Consortium
2) Chemical Probe Portal
3) Open Science Probes