### PR TITLE
remove duplicate phewas entries

### DIFF
--- a/mrtarget/resources/evidences_sources.txt
+++ b/mrtarget/resources/evidences_sources.txt
@@ -8,7 +8,6 @@ http://storage.googleapis.com/ot-releases/18.08/genomics_england-23-07-2018.json
 http://storage.googleapis.com/ot-releases/18.08/gwas-06-08-2018.json.gz
 http://storage.googleapis.com/ot-releases/18.08/intogen-23-07-2018.json.gz
 http://storage.googleapis.com/ot-releases/18.08/phenodigm-17-08-2018.json.gz
-http://storage.googleapis.com/ot-releases/18.08/phewas_catalog-01-01-2018.json
 http://storage.googleapis.com/ot-releases/18.08/phewas_catalog-11-09-2017.json.gz
 http://storage.googleapis.com/ot-releases/18.08/progeny-23-07-2018.json.gz
 http://storage.googleapis.com/ot-releases/18.08/reactome-19-07-2018.json.gz


### PR DESCRIPTION
There are two entries for the phewas data source (http://storage.googleapis.com/ot-releases/18.08/phewas_catalog-01-01-2018.json and http://storage.googleapis.com/ot-releases/18.08/phewas_catalog-11-09-2017.json.gz). This change removes the one that was not used for 18.08 release (note that the file still exists in the storage bucket, but that is outside the scope of this fix).