### PR TITLE
rewrote unitprot download to use multithread and compression

### DIFF
--- a/mrtarget/modules/Uniprot.py
+++ b/mrtarget/modules/Uniprot.py
@@ -1,4 +1,4 @@
-from StringIO import StringIO
+from cStringIO import StringIO
 import logging
 from xml.etree import cElementTree as ElementTree
 import requests
@@ -7,7 +7,11 @@ from mrtarget.common.UniprotIO import UniprotIterator, Parser
 from requests.exceptions import Timeout, HTTPError, ConnectionError
 import jsonpickle
 import base64
+from requests_futures.sessions import FuturesSession
+from concurrent.futures import ThreadPoolExecutor
+import gzip
 
+import elasticsearch
 from mrtarget.Settings import Config, build_uniprot_query
 
 
@@ -21,118 +25,55 @@ def sanitise_dict_for_json(d):
             del d[k]
     return d
 
-class OLDUniprotDownloader():
-    """ this class is deprecated
-    """
-    def __init__(self,
-                 query="reviewed:yes+AND+organism:9606",
-                 format="xml",
-                 chunk_size=1000,
-                 timeout=300,
-                 pg_session=None):
-        self.query = query
-        self.format = "&format=" + format
-        self.url = "http://www.uniprot.org/uniprot/?query="
-        self.chunk_size = chunk_size
-        self.timeout = timeout
-        self.pg = pg_session
-        self.NS = "{http://uniprot.org/uniprot}"
-        self.logger = logging.getLogger(__name__)
-
-
-    def get_entry(self):
-        offset = 0
-        data = self.get_data(self.chunk_size, offset)
-        while data.content:
-            for xml in self._iterate_xml(StringIO(data.content)):
-                seqrec = Parser(xml, return_raw_comments=True).parse()
-                self._save_to_postgresql(seqrec.id, ElementTree.tostring(xml))
-                yield seqrec
-            offset += self.chunk_size
-            data = self.get_data(self.chunk_size, offset)
-
-    def _iterate_xml(self, handle):
-        for event, elem in ElementTree.iterparse(handle, events=("start", "end")):
-            if event == "end" and elem.tag == self.NS + "entry":
-                yield elem
-                elem.clear()
-
-    def get_data(self, limit, offset):
-        if offset:
-            url = self.url + self.query + self.format + "&limit=%i&offset=%i" % (limit, offset)
-        else:
-            url = self.url + self.query + self.format + "&limit=%i" % (limit)
-        try:
-            r = requests.get(url, timeout=self.timeout)
-            if r.status_code == 200:
-                return r
-            else:
-                raise IOError('cannot get data from uniprot.org')
-        except (ConnectionError, Timeout, HTTPError) as e:
-            raise IOError(e)
-
-    def get_single_entry(self, uniprotid):
-        uniprot_xml = self.get_single_entry_xml(uniprotid)
-        if uniprot_xml:
-            return UniprotIterator(StringIO(uniprot_xml), return_raw_comments=True).next()
-        else:
-            self.logger.debug("cannot get uniprot data for uniprot id %s" % uniprotid)
-
-    def get_single_entry_xml(self, uniprotid):
-        return self.get_single_entry_xml_remote(uniprotid)
-
-
-    def get_single_entry_xml_remote(self, uniprotid):
-        url = self.url + uniprotid + self.format
-        r = requests.get(url, timeout=60)
-        if r.status_code == 200:
-            return r.content
-        else:
-            self.logger.debug('cannot get data from remote uniprot.org for uniprotid: %s' % uniprotid)
-        return
-
 
 class UniprotDownloader():
     def __init__(self,
-                 loader,
-                 query="reviewed:yes+AND+organism:9606",
-                 format="xml",
-                 chunk_size=1000,
-                 timeout=300,):
-        self.query = build_uniprot_query(Config.MINIMAL_ENSEMBL) if Config.MINIMAL else query
-        self.format = "&format=" + format
-        self.url = "http://www.uniprot.org/uniprot/?query="
-        self.chunk_size = chunk_size
-        self.timeout = timeout
-        self.loader = Loader(loader.es, chunk_size=10,
-                             dry_run=loader.is_dry_run())
+                 loader):
+        #the trailing slash is required by uniprot
+        self.url = "http://www.uniprot.org/uniprot/"
+        self.urlparams = dict()
+        self.urlparams["query"] = build_uniprot_query(Config.MINIMAL_ENSEMBL) if Config.MINIMAL else "reviewed:yes+AND+organism:9606"
+        self.urlparams["format"] = "xml"
+        #requests will not transparently de-compress for us
+        #if we use this, we have to ungzip it ourselves
+        self.urlparams["compress"] = "yes"
+
+        #size of chunks to get from uniprot
+        self.chunk_size = 1000
+        #timeout for queries to uniprot
+        self.timeout = 300
+
+        #number of concurrent requests
+        self.workers = 32
+
+        self.loader = loader
         self.NS = "{http://uniprot.org/uniprot}"
         self.logger = logging.getLogger(__name__)
 
     def cache_human_entries(self):
-        # self._delete_cache()
-        offset = 0
-        c=0
-        data = self._get_data_from_remote(self.chunk_size, offset)
-        while data.content:
-            for xml in self._iterate_xml(StringIO(data.content)):
-                seqrec = Parser(xml, return_raw_comments=True).parse()
-                '''sanitise for json'''
-                # seqrec.annotations = sanitise_dict_for_json(seqrec.annotations)
-                    # if '.' in k:
-                    #     k_sane = k.replace('.', '-')
-                    #     seqrec.annotations[k_sane] = seqrec.annotations[k]
-                    #     del seqrec.annotations[k]
-                    # if 'dbxref_extended' in seqrec.annotations and \
-                    #     'Gene3D' in seqrec.annotations['dbxref_extended']:
-                    #     del seqrec.annotations['dbxref_extended']['Gene3D']
+        with FuturesSession(executor=ThreadPoolExecutor(max_workers=self.workers)) as session:
 
-                self._save_to_elasticsearch(seqrec.id, seqrec)
-                c+=1
-            offset += self.chunk_size
-            self.logger.info('downloaded %i entries from uniprot'%c)
-            data = self._get_data_from_remote(self.chunk_size, offset)
-        self.logger.info('downloaded %i entries from uniprot'%c)
+            #query to get hoe many to retrieve
+            future = self._get_data_from_remote(session, 1,0)
+            total = int(future.result().headers['X-Total-Results'])
+            self.logger.info("Looking for %i uniprot entries", total)
+
+            #create a futures for each of the pages
+            futures = []
+            offset = 0
+            while offset < total:
+                futures.append(self._get_data_from_remote(session, self.chunk_size, offset))
+                offset += self.chunk_size
+
+            self.logger.info("Queued %i futures for uniprot", len(futures))
+
+            #now loop over the responses of the futures
+            #callbacks will put into elastic, so just need to loop over to make sure
+            #they are all finished
+            for future in futures:
+                future.result()
+
+            self.logger.info('downloaded %i entries from uniprot'%total)
 
     def _iterate_xml(self, handle):
         for event, elem in ElementTree.iterparse(handle, events=("start", "end")):
@@ -140,69 +81,35 @@ class UniprotDownloader():
                 yield elem
                 elem.clear()
 
-    def _get_data_from_remote(self, limit, offset):
+    def _get_data_from_remote(self, session, limit, offset):
+        #make a local copy for this query of the parameters
+        params = dict(self.urlparams)
+        #set the paging
+        if limit:
+            params["limit"] = limit
         if offset:
-            url = self.url + self.query + self.format + "&limit=%i&offset=%i" % (limit, offset)
-        else:
-            url = self.url + self.query + self.format + "&limit=%i" % (limit)
+            params["offset"] = offset
+
+        self.logger.debug('querying url %s with params %s', self.url, params)
+        return session.get(self.url, params=params, timeout=self.timeout, background_callback=self._cb_get)
+
+    def _cb_get(self, session, response):
         try:
-            r = requests.get(url, timeout=self.timeout)
-            if r.status_code == 200:
-                return r
-            else:
-                raise IOError('cannot get data from uniprot.org')
+            self.logger.debug('Got response for %s',response.url)
+            if response.status_code is not 200:
+                raise IOError('unable to get data from uniprot.org ('+response.status_code+')')
         except (ConnectionError, Timeout, HTTPError) as e:
             raise IOError(e)
+        if response is not None:
+            with gzip.GzipFile(fileobj=StringIO(response.content)) as gzipfile:
+                for xml in self._iterate_xml(gzipfile):
+                    result = Parser(xml, return_raw_comments=True).parse()
+                    self._save_to_elasticsearch(result.id, result)
 
-
-    # def _save_to_postgresql(self, uniprotid, uniprot_xml):
-    #     entry = self.session.query(UniprotInfo).filter_by(uniprot_accession=uniprotid).count()
-    #     if not entry:
-    #         self.session.add(UniprotInfo(uniprot_accession=uniprotid,
-    #                                 uniprot_entry=uniprot_xml))
-    #         self.session.commit()
-    #         self.cached_count+=1
-    #         if (self.cached_count%5000)==0:
-    #             self.logger.info("Cached %i entries from uniprot to local postgres"%self.cached_count)
 
     def _save_to_elasticsearch(self, uniprotid, seqrec):
-        # seqrec = UniprotIterator(StringIO(uniprot_xml), 'uniprot-xml').next()
         json_seqrec = base64.b64encode(jsonpickle.encode(seqrec))
-        # pprint(jsonpickle.json.loads(json_seqrec))
         self.loader.put(Config.ELASTICSEARCH_UNIPROT_INDEX_NAME,
                         Config.ELASTICSEARCH_UNIPROT_DOC_NAME,
                         uniprotid,
                         dict(entry =json_seqrec))
-        # entry = self.session.query(UniprotInfo).filter_by(uniprot_accession=uniprotid).count()
-        # if not entry:
-        #     self.session.add(UniprotInfo(uniprot_accession=uniprotid,
-        #                                  uniprot_entry=uniprot_xml))
-        #     self.session.commit()
-        #     self.cached_count += 1
-        #     if (self.cached_count % 5000) == 0:
-        #         self.logger.info("Cached %i entries from uniprot to local postgres" % self.cached_count)
-
-    # def _delete_cache(self):
-    #     self.cached_count = 0
-    #     rows_deleted= self.session.query(UniprotInfo).delete()
-    #     if rows_deleted:
-    #         self.logger.info('deleted %i rows from uniprot_info'%rows_deleted)
-
-
-
-class UniprotData():
-    """ Retrieve data for a uniprot entry from the local cache or the remote website uniprot.org
-    """
-
-    def __init__(self, adapter):
-        self.adapter = adapter
-        self.session = adapter.session
-
-    #TODO: method to retrieve a single uniprot entry from the db cache with failover to uniprot.org
-
-
-
-
-'''store seqrec as json
-jsonpickle.dumps(a, unpicklable=False, make_refs=False)
-'''

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,8 @@ envparse
 certifi
 elasticsearch-dsl>=5.0.0,<6.0.0
 networkx==1.9.1
-requests>=2.11.1,<3.0
+requests
+requests-futures
 ujson==1.35
 iso8601>=0.1.11 #required by opentargets
 opentargets


### PR DESCRIPTION
Solves opentargets/platform#128 by improving uniprot download.

Uses python-requests to multi-thread (but not multi-process!) the pages downloaded from the Uniprot API. Also parses and saves to elasticsearch on those multiple threads too, though speedup is less due to GIL in cPython. 

Also uses compress from uniprot API to minimise network traffic for more speed boost, as well as better parameter handling and URL construction to help prevent future issues.