### PR TITLE
changes to allow restoration from remote urls

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - "xpack.security.enabled=false"
       - "bootstrap.memory_lock=true"
       #allow downloading from open targets google buckets
-      - repositories.url.allowed_urls=https://storage.googleapis.com/open-targets-data-releases/*
+      - repositories.url.allowed_urls=https://storage.googleapis.com/open-targets-data-releases/*,https://*.amazonaws.com/*
     volumes:
       #use a volume for persistence / performance
       - esdata:/usr/share/elasticsearch/data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,8 +12,8 @@ services:
       - "ES_JAVA_OPTS=-Xms12g -Xmx12g"
       - "xpack.security.enabled=false"
       - "bootstrap.memory_lock=true"
-      #allow downloading from open targets google buckets
-      - repositories.url.allowed_urls=https://storage.googleapis.com/open-targets-data-releases/*,https://*.amazonaws.com/*
+      #allow downloading from google buckets
+      - repositories.url.allowed_urls=https://storage.googleapis.com/*,https://*.amazonaws.com/*
     volumes:
       #use a volume for persistence / performance
       - esdata:/usr/share/elasticsearch/data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,14 +2,18 @@ version: "3.6"
 services:
       
   elasticsearch:
-    image: elasticsearch:5.6.11
+    #image: elasticsearch:5.6.11
+    #note that the docker hub version doesn't allow restores for some reason...
+    image: docker.elastic.co/elasticsearch/elasticsearch:5.6.11
     ports:
       - 9200:9200
     environment:
       # assign more memory to JVM 
-      - ES_JAVA_OPTS=-Xms12g -Xmx12g
-      - xpack.security.enabled=false
-      - bootstrap.memory_lock=true
+      - "ES_JAVA_OPTS=-Xms12g -Xmx12g"
+      - "xpack.security.enabled=false"
+      - "bootstrap.memory_lock=true"
+      #allow downloading from open targets google buckets
+      - repositories.url.allowed_urls=https://storage.googleapis.com/open-targets-data-releases/*
     volumes:
       #use a volume for persistence / performance
       - esdata:/usr/share/elasticsearch/data


### PR DESCRIPTION
This allows users to use this docker-compose and follow the procedure we describe for restoring elasticsearch at https://docs.targetvalidation.org/faq/spin-your-own-instance