### PR TITLE
pin EFO version

### DIFF
--- a/mrtarget/resources/ontology_config.ini
+++ b/mrtarget/resources/ontology_config.ini
@@ -1,7 +1,7 @@
 [uris]
 hpo=https://raw.githubusercontent.com/obophenotype/human-phenotype-ontology/master/hp.owl
 mp=http://www.informatics.jax.org/downloads/reports/mp.owl
-efo=https://raw.githubusercontent.com/EBISPOT/efo/master/efo_inferred_all.owl
+efo=https://raw.githubusercontent.com/EBISPOT/efo/v2018-09-17/efo_inferred_all.owl
 so=https://github.com/The-Sequence-Ontology/SO-Ontologies/blob/master/releases/so-xp.owl/so-xp.owl?raw=true
 eco=https://raw.githubusercontent.com/evidenceontology/evidenceontology/master/eco.owl
 pato=https://raw.githubusercontent.com/pato-ontology/pato/master/pato.owl


### PR DESCRIPTION
EFO v2.101 (15/10/2018) seems to break with a transitiveClosure stack overflow problem. To work around this problems, this pull request fixes the version of EFO to a specific release which is known to work.