### PR TITLE
Af reactome fix

### DIFF
--- a/mrtarget/modules/Reactome.py
+++ b/mrtarget/modules/Reactome.py
@@ -136,14 +136,19 @@ class ReactomeProcess():
                 for path in paths:
                     for p in path:
                         ancestors.add(p)
+
+                #ensure these are 
+                children = tuple(self.g.successors(node))
+                parents = tuple(self.g.predecessors(node))
+
                 self.loader.put(index_name=Config.ELASTICSEARCH_REACTOME_INDEX_NAME,
                                 doc_type=Config.ELASTICSEARCH_REACTOME_REACTION_DOC_NAME,
                                 ID=node,
                                 body=dict(id=node,
                                           label=node_data['name'],
                                           path=paths,
-                                          children=self.g.successors(node),
-                                          parents=self.g.predecessors(node),
+                                          children=children,
+                                          parents=parents,
                                           is_root=node == root,
                                           ancestors=list(ancestors)
                                           ))

--- a/mrtarget/modules/Reactome.py
+++ b/mrtarget/modules/Reactome.py
@@ -137,7 +137,8 @@ class ReactomeProcess():
                     for p in path:
                         ancestors.add(p)
 
-                #ensure these are 
+                #ensure these are real tuples, not generators
+                #otherwise they can't be serialized to json
                 children = tuple(self.g.successors(node))
                 parents = tuple(self.g.predecessors(node))
 


### PR DESCRIPTION
Fix a bug in reactome serialisation by ensuring things to be serialised are explicitly tuples and not implicit generator objects which some serializer versions cannot appropriately handle.