### PR TITLE
Remove legacy references to $(VALIDATE_CMD)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -140,7 +140,6 @@ $(LOG_PATH)/out.$(ES_PREFIX).val.chembl.log : $(JSON_PATH)/chembl.json.gz $(LOG_
 
 .PHONY: validate_cosmic
 validate_cosmic : $(LOG_PATH)/out.$(ES_PREFIX).val.cosmic.log
-	$(VALIDATE_CMD)
 
 $(JSON_PATH)/cosmic.json.gz :
 	curl --silent https://storage.googleapis.com/ot-releases/18.08/cosmic-24-05-2018.json.gz | gunzip -c -- | shuf -n $(NUMBER_TO_KEEP) | gzip > $(JSON_PATH)/cosmic.json.gz
@@ -152,7 +151,6 @@ $(LOG_PATH)/out.$(ES_PREFIX).val.cosmic.log : $(JSON_PATH)/cosmic.json.gz $(LOG_
 
 .PHONY: validate_europepmc
 validate_europepmc : $(LOG_PATH)/out.$(ES_PREFIX).val.europepmc.log
-	$(VALIDATE_CMD)
 
 $(JSON_PATH)/europepmc.json.gz :
 	curl --silent https://storage.googleapis.com/ot-releases/18.08/europepmc-27-07-2018.json.gz | gunzip -c -- | shuf -n $(NUMBER_TO_KEEP) | gzip > $(JSON_PATH)/europepmc.json.gz
@@ -164,7 +162,6 @@ $(LOG_PATH)/out.$(ES_PREFIX).val.europepmc.log : $(JSON_PATH)/europepmc.json.gz 
 
 .PHONY: validate_eva
 validate_eva : $(LOG_PATH)/out.$(ES_PREFIX).val.eva.log
-	$(VALIDATE_CMD)
 
 $(JSON_PATH)/eva.json.gz :
 	curl --silent https://storage.googleapis.com/ot-releases/18.08/eva-02-08-2018.json.gz | gunzip -c -- | shuf -n $(NUMBER_TO_KEEP) | gzip > $(JSON_PATH)/eva.json.gz
@@ -177,7 +174,6 @@ $(LOG_PATH)/out.$(ES_PREFIX).val.eva.log : $(JSON_PATH)/eva.json.gz $(LOG_PATH)/
 
 .PHONY: validate_gene2phenotype
 validate_gene2phenotype : $(LOG_PATH)/out.$(ES_PREFIX).val.gene2phenotype.log
-	$(VALIDATE_CMD)
 
 $(JSON_PATH)/gene2phenotype.json.gz :
 	curl --silent https://storage.googleapis.com/ot-releases/18.08/gene2phenotype-27-07-2018.json.gz | gunzip -c -- | shuf -n $(NUMBER_TO_KEEP) | gzip > $(JSON_PATH)/gene2phenotype.json.gz
@@ -189,7 +185,6 @@ $(LOG_PATH)/out.$(ES_PREFIX).val.gene2phenotype.log :  $(JSON_PATH)/gene2phenoty
 
 .PHONY: validate_genomics_england
 validate_genomics_england : $(LOG_PATH)/out.$(ES_PREFIX).val.genomics_england.log
-	$(VALIDATE_CMD)
 
 $(JSON_PATH)/genomics_england.json.gz :
 	curl --silent https://storage.googleapis.com/ot-releases/18.08/genomics_england-23-07-2018.json.gz | gunzip -c -- | shuf -n $(NUMBER_TO_KEEP) | gzip > $(JSON_PATH)/genomics_england.json.gz
@@ -201,7 +196,6 @@ $(LOG_PATH)/out.$(ES_PREFIX).val.genomics_england.log : $(JSON_PATH)/genomics_en
 
 .PHONY: validate_gwas
 validate_gwas : $(LOG_PATH)/out.$(ES_PREFIX).val.gwas.log
-	$(VALIDATE_CMD)
 
 $(JSON_PATH)/gwas.json.gz :
 	curl --silent https://storage.googleapis.com/ot-releases/18.08/gwas-06-08-2018.json.gz | gunzip -c -- | shuf -n $(NUMBER_TO_KEEP) | gzip > $(JSON_PATH)/gwas.json.gz
@@ -213,7 +207,6 @@ $(LOG_PATH)/out.$(ES_PREFIX).val.gwas.log : $(JSON_PATH)/gwas.json.gz $(LOG_PATH
 
 .PHONY: validate_intogen
 validate_intogen : $(LOG_PATH)/out.$(ES_PREFIX).val.intogen.log 
-	$(VALIDATE_CMD)
 
 $(JSON_PATH)/intogen.json.gz :
 	curl --silent https://storage.googleapis.com/ot-releases/18.08/intogen-23-07-2018.json.gz | gunzip -c -- | shuf -n $(NUMBER_TO_KEEP) | gzip > $(JSON_PATH)/intogen.json.gz
@@ -225,7 +218,6 @@ $(LOG_PATH)/out.$(ES_PREFIX).val.intogen.log : $(JSON_PATH)/intogen.json.gz $(LO
 
 .PHONY: validate_phenodigm
 validate_phenodigm: $(LOG_PATH)/out.$(ES_PREFIX).val.phenodigm.log
-	$(VALIDATE_CMD)
 
 $(JSON_PATH)/phenodigm.json.gz:
 	curl --silent https://storage.googleapis.com/ot-releases/18.08/phenodigm-17-08-2018.json.gz | gunzip -c -- | shuf -n $(NUMBER_TO_KEEP) | gzip > $(JSON_PATH)/phenodigm.json.gz
@@ -237,7 +229,6 @@ $(LOG_PATH)/out.$(ES_PREFIX).val.phenodigm.log : $(JSON_PATH)/phenodigm.json.gz 
 
 .PHONY: validate_phewas_catalog
 validate_phewas_catalog : $(LOG_PATH)/out.$(ES_PREFIX).val.phewas_catalog.log
-	$(VALIDATE_CMD)
 
 $(JSON_PATH)/phewas_catalog.json.gz:
 	curl --silent https://storage.googleapis.com/ot-releases/18.08/phewas_catalog-11-09-2017.json.gz | gunzip -c -- | shuf -n $(NUMBER_TO_KEEP) | gzip > $(JSON_PATH)/phewas_catalog.json.gz
@@ -249,7 +240,6 @@ $(LOG_PATH)/out.$(ES_PREFIX).val.phewas_catalog.log : $(JSON_PATH)/phewas_catalo
 
 .PHONY: validate_progeny
 validate_progeny : $(LOG_PATH)/out.$(ES_PREFIX).val.progeny.log
-	$(VALIDATE_CMD)
 
 $(JSON_PATH)/progeny.json.gz:
 	curl --silent https://storage.googleapis.com/ot-releases/18.08/progeny-23-07-2018.json.gz | gunzip -c -- | shuf -n $(NUMBER_TO_KEEP) | gzip > $(JSON_PATH)/progeny.json.gz
@@ -261,7 +251,6 @@ $(LOG_PATH)/out.$(ES_PREFIX).val.progeny.log : $(JSON_PATH)/progeny.json.gz $(LO
 
 .PHONY: validate_reactome
 validate_reactome : $(LOG_PATH)/out.$(ES_PREFIX).val.reactome.log 
-	$(VALIDATE_CMD)
 
 $(JSON_PATH)/reactome.json.gz:
 	curl --silent https://storage.googleapis.com/ot-releases/18.08/reactome-19-07-2018.json.gz | gunzip -c -- | shuf -n $(NUMBER_TO_KEEP) | gzip > $(JSON_PATH)/reactome.json.gz
@@ -273,7 +262,6 @@ $(LOG_PATH)/out.$(ES_PREFIX).val.reactome.log : $(JSON_PATH)/reactome.json.gz $(
 
 .PHONY: validate_slapenrich
 validate_slapenrich : $(LOG_PATH)/out.$(ES_PREFIX).val.slapenrich.log
-	$(VALIDATE_CMD)
 
 $(JSON_PATH)/slapenrich.json.gz:
 	curl --silent https://storage.googleapis.com/ot-releases/18.08/slapenrich-27-07-2018.json.gz | gunzip -c -- | shuf -n $(NUMBER_TO_KEEP) | gzip > $(JSON_PATH)/slapenrich.json.gz
@@ -285,7 +273,6 @@ $(LOG_PATH)/out.$(ES_PREFIX).val.slapenrich.log : $(JSON_PATH)/slapenrich.json.g
 
 .PHONY: validate_uniprot
 validate_uniprot : $(LOG_PATH)/out.$(ES_PREFIX).val.uniprot.log
-	$(VALIDATE_CMD)
 
 $(JSON_PATH)/uniprot.json.gz:
 	curl --silent https://storage.googleapis.com/ot-releases/18.08/uniprot-30-07-2018.json.gz | gunzip -c -- | shuf -n $(NUMBER_TO_KEEP) | gzip > $(JSON_PATH)/uniprot.json.gz


### PR DESCRIPTION
The Makefile still had references to the (now empty) VALIDATE_CMD variable, which was a hangover from my initial version of the Makefile and no longer required.