### PR TITLE
Remove logging of every single ChEMBL ID

### DIFF
--- a/mrtarget/modules/ChEMBL.py
+++ b/mrtarget/modules/ChEMBL.py
@@ -189,12 +189,10 @@ class ChEMBLLookup(object):
                                                                fields=['target.id',
                                                                        'disease.id',
                                                                        'evidence.target2drug.urls'])):
-            self._logger.info('retrieving ChEMBL evidence...')
             molecule_ids = [i['url'].split('/')[-1] for i in e['evidence']['target2drug']['urls'] if
                            '/compound/' in i['url']]
             if molecule_ids:
                 molecule_id=molecule_ids[0]
-                self._logger.info(molecule_id)
 
                 if c % 200 == 0:
                     self._logger.debug('retrieving ChEMBL evidence... %s', molecule_id)


### PR DESCRIPTION
Before this change, the ChEMBL module logs two lines (at `INFO` log level) for every single molecule. This leads to very verbose log output, and potentially useful log messages getting lost in the noise.

e.g. during a recent full run, 823000 lines out of 824579, about 99.8% were unnecessary.
