### PR TITLE
Af dependency travis fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,9 @@ before_install:
   - docker run -d -p 9200:9200 -p 9300:9300 --name=ES elasticsearch:5.6.11
 install:
   - pip install -r requirements.txt
+  - pip install -r requirements.dev.txt
   - pip install -e .
+  - pipdeptree
 script:
   - make dry_run
   - pytest --cov=mrtarget --cov-report term tests/ --fulltrace

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,0 +1,11 @@
+
+#transitively includes pytest
+pytest-cov
+
+mock
+nose
+toolz
+pylint
+pipdeptree
+
+codecov

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,13 +28,6 @@ scikit-learn
 biopython
 petl
 
-pytest-cov
-#transitively includes pytest
-mock
-nose
-toolz
-pylint
-
 rdflib
 colorama
 psutil

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,8 @@
 requests
 future
 redislite
+#AF 15/11/18 transitive pinning to 2.x.x to solve AttributeError: 'UnixDomainSocketConnection' object has no attribute '_buffer_cutoff' 
+redis<=2.10.6
 addict
 envparse
 elasticsearch-dsl>=5.0.0,<6.0.0


### PR DESCRIPTION
Pin redis transitive dependency via redislite to v2.x.x since it is functional and the latest 3.x.x is not.