### PR TITLE
fix mp data reference

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,7 +124,7 @@ base_gene: $(LOG_PATH)/out.$(ES_PREFIX).gen.log
 $(LOG_PATH)/out.$(ES_PREFIX).gen.log : $(LOG_PATH)/out.$(ES_PREFIX).rea.log $(LOG_PATH)/out.$(ES_PREFIX).ens.log $(LOG_PATH)/out.$(ES_PREFIX).uni.log $(LOG_PATH)/out.$(ES_PREFIX).hpa.log $(LOG_PATH)/out.$(ES_PREFIX).mp.log
 	mkdir -p $(LOG_PATH)
 	$(ELASTIC_CHECK_CMD)
-	$(INDEX_CMD) $(ES_PREFIX)_reactome-data $(ES_PREFIX)_ensembl-data $(ES_PREFIX)_uniprot-data $(ES_PREFIX)_expression-data $(ES_PREFIX)mp-data
+	$(INDEX_CMD) $(ES_PREFIX)_reactome-data $(ES_PREFIX)_ensembl-data $(ES_PREFIX)_uniprot-data $(ES_PREFIX)_expression-data $(ES_PREFIX)_mp-data
 	$(MRTARGET_CMD) --gen $(ES_PREFIX) 2>&1 | tee $(LOG_PATH)/out.$(ES_PREFIX).gen.log
 	sleep 60
 


### PR DESCRIPTION
Fix for a minor typo in the Makefile related to removal and recreation of the mp-data index