### PR TITLE
add pipe fail parameter to bash within make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
 # Makefile for Open Targets data pipeline
 # Based on steps in https://github.com/opentargets/data_release/wiki/OT011-Data-Processing-(Backend)
 
+#ensure pipes behave correctly
+SHELL = /bin/bash
+.SHELLFLAGS = -o pipefail -c
 
 #get the directory the makefile is in
 # from https://stackoverflow.com/questions/18136918


### PR DESCRIPTION
Minor pull request to solve opentargets/platform#295 by ensuring bash within make respects error codes from pipes correctly