### PR TITLE
flush and wait when populating index

### DIFF
--- a/mrtarget/modules/ECO.py
+++ b/mrtarget/modules/ECO.py
@@ -67,6 +67,7 @@ class EcoProcess():
                             doc_type=Config.ELASTICSEARCH_ECO_DOC_NAME,
                             ID=eco_id,
                             body=eco_obj)
+        self.loader.flush_all_and_wait(Config.ELASTICSEARCH_ECO_INDEX_NAME)
 
     """
     Run a series of QC tests on EFO elasticsearch index. Returns a dictionary

--- a/mrtarget/modules/EFO.py
+++ b/mrtarget/modules/EFO.py
@@ -152,6 +152,7 @@ class EfoProcess():
                             doc_type=Config.ELASTICSEARCH_EFO_LABEL_DOC_NAME,
                             ID=efo_id,
                             body = efo_obj)
+        self.loader.flush_all_and_wait(Config.ELASTICSEARCH_EFO_LABEL_INDEX_NAME)
     """
     Run a series of QC tests on EFO elasticsearch index. Returns a dictionary
     of string test names and result objects

--- a/mrtarget/modules/GeneData.py
+++ b/mrtarget/modules/GeneData.py
@@ -474,6 +474,7 @@ class GeneManager():
         for w in workers:
             w.join()
 
+        self.loader.flush_all_and_wait(Config.ELASTICSEARCH_GENE_NAME_INDEX_NAME)
         self._logger.info('all gene objects pushed to elasticsearch')
 
 


### PR DESCRIPTION
Make sure that the index is flushed and up to date before stage finish. This helps ensure that an index is up to date and ready before proceeding to the next step.