### PR TITLE
Af lookup cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -135,6 +135,9 @@ Temporary Items
 # IntelliJ
 out/
 
+#eclipse and other IDEs
+.settings/
+
 # mpeltonen/sbt-idea plugin
 .idea_modules/
 

--- a/.settings/.gitignore
+++ b/.settings/.gitignore
@@ -1,1 +1,0 @@
-/org.eclipse.core.resources.prefs

--- a/mrtarget/common/EvidencesHelpers.py
+++ b/mrtarget/common/EvidencesHelpers.py
@@ -26,9 +26,6 @@ def make_lookup_data(es_client, redis_client):
         redis_client, [], (
             LookUpDataType.TARGET,
             LookUpDataType.DISEASE,
-            LookUpDataType.EFO,
-            LookUpDataType.HPO,
-            LookUpDataType.MP,
             LookUpDataType.ECO
         )
         ).lookup

--- a/mrtarget/common/EvidencesHelpers.py
+++ b/mrtarget/common/EvidencesHelpers.py
@@ -23,17 +23,15 @@ _l = logging.getLogger(__name__)
 
 def make_lookup_data(es_client, redis_client):
     return LookUpDataRetriever(es_client,
-                        redis_client,
-                        data_types=(
-                            LookUpDataType.TARGET,
-                            LookUpDataType.DISEASE,
-                            LookUpDataType.EFO,
-                            LookUpDataType.HPO,
-                            LookUpDataType.MP,
-                            LookUpDataType.ECO
-                        ),
-                        autoload=True,
-                        ).lookup
+        redis_client, [], (
+            LookUpDataType.TARGET,
+            LookUpDataType.DISEASE,
+            LookUpDataType.EFO,
+            LookUpDataType.HPO,
+            LookUpDataType.MP,
+            LookUpDataType.ECO
+        )
+        ).lookup
 
 
 class ProcessContext(object):

--- a/mrtarget/common/LookupHelpers.py
+++ b/mrtarget/common/LookupHelpers.py
@@ -97,7 +97,7 @@ class LookUpDataRetriever(object):
             elif dt == LookUpDataType.HPA:
                 self.lookup.available_hpa = HPALookUpTable(self.es, 'HPA_LOOKUP', self.r_server)
 
-            self._logger.info("loaded %s in %ss" % (dt, str(int(time.time() - start_time)))
+            self._logger.info("loaded %s in %ss" % (dt, str(int(time.time() - start_time))))
 
     def set_r_server(self, r_server):
         self.r_server = r_server

--- a/mrtarget/common/LookupHelpers.py
+++ b/mrtarget/common/LookupHelpers.py
@@ -59,18 +59,13 @@ class LookUpDataType(object):
 
 class LookUpDataRetriever(object):
     def __init__(self,
-                 es=None,
-                 r_server=None,
-                 targets=[],
-                 data_types=(LookUpDataType.TARGET,
-                             LookUpDataType.DISEASE,
-                             LookUpDataType.ECO),
-                 autoload=True,
-                #  es_pub=None,
+                 es,
+                 r_server,
+                 targets,
+                 data_types
                  ):
 
         self.es = es
-        # self.es_pub = es_pub
         self.r_server = r_server
 
         self.esquery = ESQuery(self.es)
@@ -86,11 +81,11 @@ class LookUpDataRetriever(object):
         for dt in data_types:
             start_time = time.time()
             if dt == LookUpDataType.TARGET:
-                self._get_gene_info(targets, autoload=autoload)
+                self._get_gene_info(targets, True)
             elif dt == LookUpDataType.DISEASE:
-                self._get_available_efos()
+                self.lookup.available_efos = EFOLookUpTable(self.es, 'EFO_LOOKUP', self.r_server)
             elif dt == LookUpDataType.ECO:
-                self._get_available_ecos()
+                self.lookup.available_ecos = ECOLookUpTable(self.es, 'ECO_LOOKUP', self.r_server)
             elif dt == LookUpDataType.MP:
                 self._logger.debug("get MP info")
                 self._get_mp()
@@ -103,7 +98,7 @@ class LookUpDataRetriever(object):
             elif dt == LookUpDataType.CHEMBL_DRUGS:
                 self._get_available_chembl_mappings()
             elif dt == LookUpDataType.HPA:
-                self._get_available_hpa()
+                self.lookup.available_hpa = HPALookUpTable(self.es, 'HPA_LOOKUP', self.r_server)
 
             self._logger.info("finished loading %s data into redis, took %ss" % (dt, str(time.time() - start_time)))
 
@@ -111,15 +106,6 @@ class LookUpDataRetriever(object):
         self.r_server = r_server
         self.lookup.set_r_server(r_server)
         self.esquery = ESQuery()
-
-    def _get_available_efos(self):
-        self._logger.info('getting efos')
-        self.lookup.available_efos = EFOLookUpTable(self.es, 'EFO_LOOKUP', self.r_server)
-
-    def _get_available_ecos(self):
-        self._logger.info('getting ecos')
-        self.lookup.available_ecos = ECOLookUpTable(self.es, 'ECO_LOOKUP', self.r_server)
-
 
     def _get_gene_info(self, targets=[], autoload = True):
         self._logger.info('getting gene info')
@@ -214,11 +200,7 @@ class LookUpDataRetriever(object):
                                                            chembl_handler.molecule2synonyms,
                                                            chembl_handler._logger)
         self.lookup.chembl = chembl_handler
-
-    def _get_available_hpa(self):
-        self._logger.info('getting expressions')
-        self.lookup.available_hpa = HPALookUpTable(self.es, 'HPA_LOOKUP',
-                                                   self.r_server)
+        
 
 
 

--- a/mrtarget/modules/Association.py
+++ b/mrtarget/modules/Association.py
@@ -558,10 +558,7 @@ class ScoringProcess():
                                               LookUpDataType.TARGET,
                                               LookUpDataType.ECO,
                                               LookUpDataType.HPA
-                                          ),
-                                          autoload=True if not targets
-                                          or len(targets) > 100
-                                          else False).lookup
+                                          )).lookup
 
         if not targets:
             targets = list(self.es_query.get_all_target_ids_with_evidence_data())

--- a/mrtarget/modules/EvidenceString.py
+++ b/mrtarget/modules/EvidenceString.py
@@ -1055,9 +1055,8 @@ class EvidenceStringProcess():
 
         lookup_data = LookUpDataRetriever(self.es,
                                           self.r_server,
-                                          data_types=lookup_data_types,
-                                          autoload=True,
-                                        #   es_pub=self.es_pub,
+                                          [],
+                                          lookup_data_types,
                                           ).lookup
 
         global_stat_cache= 'global_stats.pkl'

--- a/mrtarget/modules/Evidences.py
+++ b/mrtarget/modules/Evidences.py
@@ -202,17 +202,8 @@ def validate_evidence(line, process_context):
 
         if efo_id:
             # Check disease term or phenotype term
-            # if (short_disease_id not in self.lookup_data.available_efos) and \
-            if (efo_id not in process_context.kwargs.luts.efo_ontology.current_classes) and \
-                    (efo_id not in process_context.kwargs.luts.hpo_ontology.current_classes) and \
-                    (efo_id not in process_context.kwargs.luts.mp_ontology.current_classes):
+            if efo_id not in process_context.kwargs.luts.available_efos:
                 validated_evs.explanation_type = 'invalid_disease'
-                validated_evs.explanation_str = efo_id
-                disease_failed = True
-            if (efo_id in process_context.kwargs.luts.efo_ontology.obsolete_classes) or \
-                    (efo_id in process_context.kwargs.luts.hpo_ontology.obsolete_classes) or \
-                    (efo_id in process_context.kwargs.luts.mp_ontology.obsolete_classes):
-                validated_evs.explanation_type = 'obsolete_disease'
                 validated_evs.explanation_str = efo_id
                 disease_failed = True
         else:

--- a/mrtarget/modules/SearchObjects.py
+++ b/mrtarget/modules/SearchObjects.py
@@ -289,7 +289,8 @@ class SearchObjectProcess(object):
                            max_size=1000,
                            job_timeout=180)
 
-        lookup_data = LookUpDataRetriever(self.loader.es,self.r_server,data_types=[LookUpDataType.CHEMBL_DRUGS]).lookup
+        lookup_data = LookUpDataRetriever(self.loader.es, self.r_server,
+            [],[LookUpDataType.CHEMBL_DRUGS]).lookup
 
         workers = [SearchObjectAnalyserWorker(queue,
                                               None,

--- a/mrtarget/plugins/gene/mousephenotypes.py
+++ b/mrtarget/plugins/gene/mousephenotypes.py
@@ -84,7 +84,7 @@ class MousePhenotypes(IPlugin):
                                                (LookUpDataType.MP,)
                                                ).lookup
 
-        #TOD this is a moderately hideous bit of pointless munging, but I don't have time fix it now!
+        #TODO this is a moderately hideous bit of pointless munging, but I don't have time fix it now!
 
         for mp_id,label in self.lookup_data.mp_ontology.current_classes.items():
 

--- a/mrtarget/plugins/gene/mousephenotypes.py
+++ b/mrtarget/plugins/gene/mousephenotypes.py
@@ -80,8 +80,8 @@ class MousePhenotypes(IPlugin):
         self._logger.debug("_get_mp_classes")
         self.lookup_data = LookUpDataRetriever(self.loader.es,
                                                self.r_server,
-                                               data_types=(LookUpDataType.MP,),
-                                               autoload=True
+                                               [],
+                                               (LookUpDataType.MP,)
                                                ).lookup
 
         #TOD this is a moderately hideous bit of pointless munging, but I don't have time fix it now!

--- a/tests/test_lookuphelpers.py
+++ b/tests/test_lookuphelpers.py
@@ -39,11 +39,8 @@ class LookupHelpersTestCase(unittest.TestCase):
         self.assertIsNotNone(mock_connectors.r_server)
 
         lookup_data = LookUpDataRetriever(mock_connectors.es, mock_connectors.r_server,
-                                          data_types=(
-                                              LookUpDataType.MP,
-                                          ),
-                                          autoload=True,
-                                          ).lookup
+            [], ( LookUpDataType.MP, ),
+            ).lookup
 
         self.assertIsNotNone(lookup_data)
         self.assertIsNotNone(lookup_data.mp_ontology)
@@ -60,11 +57,8 @@ class LookupHelpersTestCase(unittest.TestCase):
         self.assertIsNotNone(mock_connectors.r_server)
 
         lookup_data = LookUpDataRetriever(mock_connectors.es, mock_connectors.r_server,
-                                      data_types=(
-                                          LookUpDataType.EFO,
-                                      ),
-                                      autoload=True,
-                                      ).lookup
+            [], ( LookUpDataType.EFO, ),
+            ).lookup
 
         self.assertIsNotNone(lookup_data)
         self.assertIsNotNone(lookup_data.efo_ontology)

--- a/tests/test_lookuphelpers.py
+++ b/tests/test_lookuphelpers.py
@@ -49,23 +49,5 @@ class LookupHelpersTestCase(unittest.TestCase):
         self.assertIsNotNone(lookup_data.mp_ontology.obsolete_classes)
         self.assertTrue(len(lookup_data.mp_ontology.obsolete_classes) > 0)
 
-    @mock.patch('mrtarget.common.connection')
-    def test_efo_lookup(self, mock_connectors):
-        self._logger.debug("test_hpo_lookup")
-
-        self.assertIsNotNone(mock_connectors.es)
-        self.assertIsNotNone(mock_connectors.r_server)
-
-        lookup_data = LookUpDataRetriever(mock_connectors.es, mock_connectors.r_server,
-            [], ( LookUpDataType.EFO, ),
-            ).lookup
-
-        self.assertIsNotNone(lookup_data)
-        self.assertIsNotNone(lookup_data.efo_ontology)
-        self.assertIsNotNone(lookup_data.efo_ontology.current_classes)
-        self.assertTrue(len(lookup_data.efo_ontology.current_classes) > 8000)
-        self.assertIsNotNone(lookup_data.efo_ontology.obsolete_classes)
-        self.assertTrue(len(lookup_data.efo_ontology.obsolete_classes) > 0)
-
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Improvements to the lookup table systems to prevent double-loading of ontologies e.g. EFO and the resulting inconsistencies. Should also improve performance and maintainability by removing redundant code.