### PR TITLE
Af ontology utils update

### DIFF
--- a/mrtarget/common/LookupHelpers.py
+++ b/mrtarget/common/LookupHelpers.py
@@ -10,6 +10,8 @@ from mrtarget.common.LookupTables import EFOLookUpTable
 from mrtarget.common.LookupTables import HPALookUpTable
 from mrtarget.common.LookupTables import GeneLookUpTable
 from opentargets_ontologyutils.rdf_utils import OntologyClassReader
+import opentargets_ontologyutils.hpo
+import opentargets_ontologyutils.mp
 from mrtarget.Settings import Config, file_or_resource
 from mrtarget.common import require_all
 
@@ -134,9 +136,9 @@ class LookUpDataRetriever(object):
         Load HPO to accept phenotype terms that are not in EFO
         :return:
         '''
-        cache_file = 'processed_hpo_lookup'
         obj = OntologyClassReader()
-        obj.load_hpo_classes(Config.ONTOLOGY_CONFIG.get('uris', 'hpo'))
+        hpo_uri = Config.ONTOLOGY_CONFIG.get('uris', 'hpo')
+        opentargets_ontologyutils.hpo.get_hpo(obj, hpo_uri)
         obj.rdf_graph = None
         self.lookup.hpo_ontology = obj
 
@@ -146,8 +148,8 @@ class LookUpDataRetriever(object):
         :return:
         '''
         obj = OntologyClassReader()
-        obj.load_mammalian_phenotype_ontology(Config.ONTOLOGY_CONFIG.get('uris', 'mp'))
-        obj.get_deprecated_classes()
+        mp_uri = Config.ONTOLOGY_CONFIG.get('uris', 'mp')
+        opentargets_ontologyutils.mp.load_mammalian_phenotype_ontology(obj, mp_uri)
         obj.rdf_graph = None
         self.lookup.mp_ontology = obj
 

--- a/mrtarget/modules/ECO.py
+++ b/mrtarget/modules/ECO.py
@@ -3,6 +3,7 @@ from collections import OrderedDict
 from mrtarget.common.LookupTables import ECOLookUpTable
 from mrtarget.common.DataStructure import JSONSerializable
 from opentargets_ontologyutils.rdf_utils import OntologyClassReader
+import opentargets_ontologyutils.eco_so
 from mrtarget.Settings import Config
 import logging
 logger = logging.getLogger(__name__)
@@ -48,7 +49,8 @@ class EcoProcess():
         uri_so = Config.ONTOLOGY_CONFIG.get('uris', 'so')
         uri_eco = Config.ONTOLOGY_CONFIG.get('uris', 'eco')
 
-        self.evidence_ontology.load_evidence_classes(uri_so, uri_eco)
+        opentargets_ontologyutils.eco_so.load_evidence_classes(self.evidence_ontology, uri_so, uri_eco)
+
         for uri,label in self.evidence_ontology.current_classes.items():
             eco = ECO(uri,
                       label,

--- a/mrtarget/modules/EFO.py
+++ b/mrtarget/modules/EFO.py
@@ -3,6 +3,7 @@ from collections import OrderedDict
 from mrtarget.common.connection import PipelineConnectors
 from mrtarget.common.DataStructure import JSONSerializable
 from opentargets_ontologyutils.rdf_utils import OntologyClassReader, DiseaseUtils
+import opentargets_ontologyutils.efo
 from rdflib import URIRef
 from mrtarget.Settings import Config
 
@@ -96,7 +97,9 @@ class EfoProcess():
     def _process_ontology_data(self):
 
         self.disease_ontology = OntologyClassReader()
-        self.disease_ontology.load_open_targets_disease_ontology(Config.ONTOLOGY_CONFIG.get('uris','efo'))
+        efo_uri = Config.ONTOLOGY_CONFIG.get('uris','efo')
+        opentargets_ontologyutils.efo.load_open_targets_disease_ontology(self.disease_ontology, efo_uri)
+
         '''
         Get all phenotypes
         '''

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,9 +18,9 @@ simplejson
 
 #when installing from GitHub, a specific commit must be used for consistency
 #and to ensure dependency caching works as intended
-#git+https://github.com/opentargets/validator.git@711c098df9c82e66ff9b95412f4561c28a63b572#egg=opentargets_validator
+#git+https://github.com/opentargets/ontology-utils.git@f92222b5abf89b0c3a9c2d3cd0e683676620b380#egg=opentargets-ontologyutils
 opentargets-validator>=0.4.0
-opentargets-ontologyutils
+opentargets-ontologyutils>=1.1.0
 
 numpy
 scipy


### PR DESCRIPTION
Update pipeline to use 1.1.0 of ontology utils Requires that opentargets/ontology-utils#6 is merged first.