### PR TITLE
Af 360 hpa pypeln

### DIFF
--- a/mrtarget/modules/HPA.py
+++ b/mrtarget/modules/HPA.py
@@ -479,7 +479,7 @@ def write_on_start():
     return kwargs
 
 def write_on_done(status, resources):
-    resources['es_loader'].flush_all_and_wait()
+    resources['es_loader'].flush_all_and_wait(Config.ELASTICSEARCH_EXPRESSION_INDEX_NAME)
     resources['es_loader'].close()
 
 def write_to_elastic(data, resources):


### PR DESCRIPTION
Solves opentargets/platform#360 by removing the redis queue mulithreading.

Actually does the work on the single main thread, and compared to a pypeln implementation the single thread is 33% faster.