### PR TITLE
Fixed typo

### DIFF
--- a/mrtarget/cfg.py
+++ b/mrtarget/cfg.py
@@ -14,7 +14,7 @@ def setup_ops_parser():
 
     # configuration file with data related settings
     p.add('--data-config', help='path to data config file (YAML)',
-        env_var="DATA_CONFIG", action='store', default="mtarget.data.yml")
+        env_var="DATA_CONFIG", action='store', default="mrtarget.data.yml")
 
     # logging
     p.add("--log-config", help="logging configuration file",


### PR DESCRIPTION
There is a typo error in the cfy.py file.
default="mtarget.data.yml" 
It should be
default="mrtarget.data.yml"