### PR TITLE
remove minimum evidence string score filter

### DIFF
--- a/mrtarget/Settings.py
+++ b/mrtarget/Settings.py
@@ -97,11 +97,7 @@ class Config():
     # to the number of CPUs available
     WORKERS_NUMBER = read_option('WORKERS_NUMBER',cast=int,
                                  default=mp.cpu_count())
-
-    # setup a minimum score value for an evidence string to be accepted.
-    SCORING_MIN_VALUE_FILTER = defaultdict(lambda: 0)
-    SCORING_MIN_VALUE_FILTER['phenodigm'] = 0.4
-
+                                 
     REDISLITE_REMOTE = read_option('CTTV_REDIS_REMOTE',
                                    cast=bool, default=False)
     REDISLITE_DB_HOST, REDISLITE_DB_PORT = \

--- a/mrtarget/modules/EvidenceString.py
+++ b/mrtarget/modules/EvidenceString.py
@@ -688,14 +688,6 @@ class Evidence(JSONSerializable):
             self.logger.error(
                 "Cannot score evidence %s of type %s. Error: %s" % (self.evidence['id'], self.evidence['type'], e))
 
-        # Check for minimum score
-        if self.evidence['scores']['association_score'] < Config.SCORING_MIN_VALUE_FILTER[self.evidence['sourceID']]:
-            raise AttributeError(
-                "Evidence String datasource:%s rejected since score is too low: %s. score: %f, min score: %f" % (
-                    self.evidence['sourceID'], self.get_id(), self.evidence['scores']['association_score'],
-                    Config.SCORING_MIN_VALUE_FILTER[self.evidence['sourceID']]))
-
-
         # Apply rescaling to scores
         if self.evidence['sourceID'] in modifiers:
             self.evidence['scores']['association_score'] = modifiers[self.evidence['sourceID']](


### PR DESCRIPTION
Remove the minimum score filter. Previously had been applied to phenodigm but set to low to do anything.