### PR TITLE
partial improvement to redis configuration

### DIFF
--- a/mrtarget/CommandLine.py
+++ b/mrtarget/CommandLine.py
@@ -62,11 +62,13 @@ def main():
         logger.info('setting release version %s' % Config.RELEASE_VERSION)
 
     enable_profiling(args.profile)
+
     
-    with RedisManager():
+    
+    with RedisManager(args.redis_remote,args.redis_host, args.redis_port):
 
         es = new_es_client(args.elasticseach_nodes)
-        redis = new_redis_client()
+        redis = new_redis_client(args.redis_host, args.redis_port)
 
         #create a single query object for future use
         esquery = ESQuery(es)

--- a/mrtarget/Settings.py
+++ b/mrtarget/Settings.py
@@ -101,12 +101,7 @@ class Config():
     # setup a minimum score value for an evidence string to be accepted.
     SCORING_MIN_VALUE_FILTER = defaultdict(lambda: 0)
     SCORING_MIN_VALUE_FILTER['phenodigm'] = 0.4
-
-    REDISLITE_REMOTE = read_option('CTTV_REDIS_REMOTE',
-                                   cast=bool, default=False)
-    REDISLITE_DB_HOST, REDISLITE_DB_PORT = \
-        read_option('CTTV_REDIS_SERVER', cast=str, default='127.0.0.1:35000').split(':')
-
+    
     UNIQUE_RUN_ID = str(uuid.uuid4()).replace('-', '')[:16]
 
     # This config file is like this and no prefixes or version will be

--- a/mrtarget/cfg.py
+++ b/mrtarget/cfg.py
@@ -2,6 +2,7 @@ import os
 import yaml
 import configargparse
 import addict
+import mrtarget.common.connection
 from mrtarget.common import URLZSource
 
 def setup_ops_parser():
@@ -35,12 +36,12 @@ def setup_ops_parser():
     # use an external redis rather than spawning one ourselves
     p.add("--redis-remote", help="connect to a remote redis, instead of starting an embedded one",
         action='store_true', default=False,
-        env_var='CTTV_REDIS_REMOTE')  # TODO use a different env variable
+        env_var='REDIS_REMOTE')  # TODO use a different env variable
     p.add("--redis-host", help="redis host",
         action='store', default='localhost',
         env_var='REDIS_HOST')
     p.add("--redis-port", help="redis port",
-        action='store', default='35000',
+        action='store', default='6379',
         env_var='REDIS_PORT')
 
     # elasticsearch
@@ -124,6 +125,7 @@ def setup_ops_parser():
     p.add("--metric-file", help="generate metrics", 
         env_var="METRIC_FILE", default='release_metrics.txt')
 
+
     return p
 
 def get_ops_args():
@@ -134,6 +136,12 @@ def get_ops_args():
 
     #output all configuration values, useful for debugging
     p.print_values()
+
+    #WARNING
+    #this is a horrible hack and should be removed 
+    #once lookup and queues are handled better
+    mrtarget.common.connection.default_host = args.redis_host
+    mrtarget.common.connection.default_port = args.redis_port
 
     return args
 

--- a/mrtarget/common/connection.py
+++ b/mrtarget/common/connection.py
@@ -12,9 +12,14 @@ from mrtarget.Settings import Config
 # just one redis instance per app
 r_instance = {'instance': None}
 
-def new_redis_client():
-    return Redis(host=Config.REDISLITE_DB_HOST,
-                 port=Config.REDISLITE_DB_PORT)
+#TODO hackily use globals for now, replace with proper passing
+#once lookup and queues are handled better
+default_host = "localhost"
+default_port = 6379
+
+
+def new_redis_client(host=default_host, port=default_port):
+    return Redis(host=host, port=port)
 
 def new_es_client(hosts):
     return Elasticsearch(hosts=hosts,
@@ -35,8 +40,8 @@ of embedded redis instance, if appropriate.
 
 Use in a with statemnt, i.e.
 
-  with RedisManager as redisManager:
-    redis_client = new_redis_client()
+  with RedisManager(remote, host, port) as redisManager:
+    redis_client = new_redis_client(host, port)
     ...do stuff...
 
 Don't try and use this anywhere but the main thread. It should work,
@@ -44,14 +49,17 @@ but just don't try it!
 
 """
 class RedisManager():
-    def __init__(self):
+    def __init__(self, remote, host, port):
         self.logger = logging.getLogger(__name__)
         self.r_instance = None
+        self.remote = remote
+        self.host = host
+        self.port = port
 
     def redis_server_is_up(self):
         is_up = False
         try:
-            c = new_redis_client()
+            c = new_redis_client(self.host, self.port)
             c.ping()
             is_up = True
             self.logger.debug('detected a redis-server instance running, so attaching to it')
@@ -61,23 +69,22 @@ class RedisManager():
             return is_up
 
     def create_redislite_if_needed(self):
-        r_remote = Config.REDISLITE_REMOTE
         # check if redis server is already running it will be checked if we dont want
         # remote enabled but the local redis server instance is still running and we want
         # things implicit and stop bothering other developers forced to kill local redis
-        if not r_remote and self.redis_server_is_up():
+        if not self.remote and self.redis_server_is_up():
             raise RuntimeError("Able to connect to redis when should be creating one!")
-        elif r_remote and not self.redis_server_is_up():
+        elif self.remote and not self.redis_server_is_up():
             #we asked to use an external redis, but it doesn't exist
             raise RuntimeError("Unable to connect to redis")
 
-        if not r_remote and not self.r_instance:
+        if not self.remote and not self.r_instance:
             self.redis_db_file = tmp.mktemp(suffix='.rdb', dir='/tmp')
             self.r_instance = Redis(dbfilename=self.redis_db_file,
                 serverconfig={'save': [],
                     'maxclients': 10000,
-                    'bind': Config.REDISLITE_DB_HOST,
-                    'port': str(Config.REDISLITE_DB_PORT)})
+                    'bind': str(self.host),
+                    'port': str(self.port)})
 
     def __enter__(self):
         self.create_redislite_if_needed()

--- a/tests/test_redis_lookup_table.py
+++ b/tests/test_redis_lookup_table.py
@@ -12,7 +12,7 @@ class PicklableObject(object):
 class LookupTableTestCase(unittest.TestCase):
 
     def test_base_lookup(self):
-        with RedisManager():
+        with RedisManager(False):
             table = RedisLookupTable()
 
             test = 'this is a string test that does not need to be serialized'
@@ -22,7 +22,7 @@ class LookupTableTestCase(unittest.TestCase):
 
 
     def test_json_lookup(self):
-        with RedisManager():
+        with RedisManager(False):
             table = RedisLookupTableJson()
 
             test = {'json test':'this is a test object that can be serialized to json'}
@@ -31,7 +31,7 @@ class LookupTableTestCase(unittest.TestCase):
             self.assertEquals(table.get(key), test)
 
     def test_pickle_lookup(self):
-        with RedisManager():
+        with RedisManager(False):
             table = RedisLookupTablePickle()
 
             test = PicklableObject()

--- a/tests/test_redis_lookup_table.py
+++ b/tests/test_redis_lookup_table.py
@@ -1,6 +1,6 @@
 from mrtarget.common.Redis import RedisLookupTable, RedisLookupTableJson, RedisLookupTablePickle
 import unittest
-from mrtarget.common.connection import RedisManager
+from mrtarget.common.connection import RedisManager, new_redis_client
 
 
 class PicklableObject(object):
@@ -13,7 +13,8 @@ class LookupTableTestCase(unittest.TestCase):
 
     def test_base_lookup(self):
         with RedisManager(False, "localhost", 35000):
-            table = RedisLookupTable()
+            r_server = new_redis_client("localhost", 35000)
+            table = RedisLookupTable(r_server=r_server)
 
             test = 'this is a string test that does not need to be serialized'
             key = 'test_key'
@@ -23,7 +24,8 @@ class LookupTableTestCase(unittest.TestCase):
 
     def test_json_lookup(self):
         with RedisManager(False, "localhost", 35000):
-            table = RedisLookupTableJson()
+            r_server = new_redis_client("localhost", 35000)
+            table = RedisLookupTableJson(r_server=r_server)
 
             test = {'json test':'this is a test object that can be serialized to json'}
             key = 'test_key'
@@ -32,7 +34,8 @@ class LookupTableTestCase(unittest.TestCase):
 
     def test_pickle_lookup(self):
         with RedisManager(False, "localhost", 35000):
-            table = RedisLookupTablePickle()
+            r_server = new_redis_client("localhost", 35000)
+            table = RedisLookupTablePickle(r_server=r_server)
 
             test = PicklableObject()
             key = 'test_key'

--- a/tests/test_redis_lookup_table.py
+++ b/tests/test_redis_lookup_table.py
@@ -12,7 +12,7 @@ class PicklableObject(object):
 class LookupTableTestCase(unittest.TestCase):
 
     def test_base_lookup(self):
-        with RedisManager(False):
+        with RedisManager(False, "localhost", 35000):
             table = RedisLookupTable()
 
             test = 'this is a string test that does not need to be serialized'
@@ -22,7 +22,7 @@ class LookupTableTestCase(unittest.TestCase):
 
 
     def test_json_lookup(self):
-        with RedisManager(False):
+        with RedisManager(False, "localhost", 35000):
             table = RedisLookupTableJson()
 
             test = {'json test':'this is a test object that can be serialized to json'}
@@ -31,7 +31,7 @@ class LookupTableTestCase(unittest.TestCase):
             self.assertEquals(table.get(key), test)
 
     def test_pickle_lookup(self):
-        with RedisManager(False):
+        with RedisManager(False, "localhost", 35000):
             table = RedisLookupTablePickle()
 
             test = PicklableObject()


### PR DESCRIPTION
Remove redis client config from settings.py Still uses an ugly global, but that will be much easier to remove once weve cleaned up lookup tables and queues.