### PR TITLE
cleanup extra create_index argument that no longer exists

### DIFF
--- a/mrtarget/modules/GeneData.py
+++ b/mrtarget/modules/GeneData.py
@@ -430,8 +430,7 @@ class GeneManager():
             if not dry_run:
                 self.loader.put(Const.ELASTICSEARCH_GENE_NAME_INDEX_NAME,
                     Const.ELASTICSEARCH_GENE_NAME_DOC_NAME,
-                    geneid, gene.to_json(),
-                    create_index=False)
+                    geneid, gene.to_json())
 
         if not dry_run:
             self.loader.flush_all_and_wait(Const.ELASTICSEARCH_GENE_NAME_INDEX_NAME)

--- a/mrtarget/modules/SearchObjects.py
+++ b/mrtarget/modules/SearchObjects.py
@@ -296,5 +296,4 @@ class SearchObjectProcess(object):
         if not dry_run:
             self.loader.put(Const.ELASTICSEARCH_DATA_SEARCH_INDEX_NAME,
                 Const.ELASTICSEARCH_DATA_SEARCH_DOC_NAME+'-'+so.type,
-                so.id, so.to_json(),
-                create_index=False)
+                so.id, so.to_json())


### PR DESCRIPTION
Tidy up a couple of extra arguments to push that are no longer accepted.