### PR TITLE
don't push on PRs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ after_success:
   - docker tag "${QUAY_REPO}" "${QUAY_REPO}:${git_sha}-${TRAVIS_BRANCH}"
   #only push non-PRs
   - |
-    if ["${TRAVIS_PULL_REQUEST}" = "false"]; then
+    if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then
       docker push "${QUAY_REPO}:${TRAVIS_BRANCH}" && docker push "${QUAY_REPO}:${git_sha}-${TRAVIS_BRANCH}"
       if [ "${TRAVIS_BRANCH}" = "master" ]; then
         docker tag "${QUAY_REPO}:${TRAVIS_BRANCH}" "${QUAY_REPO}:latest"

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,15 +32,18 @@ notifications:
 after_success:
   - codecov
   - docker pull "${QUAY_REPO}:${TRAVIS_BRANCH}" || true
+  #pull the previous built image to use as a cache if possible
   - docker build --pull --cache-from "${QUAY_REPO}:${TRAVIS_BRANCH}" --tag "${QUAY_REPO}" .
   - docker login -u="${QUAY_USER}" -p="${QUAY_PASSWORD}" quay.io
-#   - git_sha="$(git rev-parse --short HEAD)" # removed since travis provides a better one to use
   - git_sha="${TRAVIS_COMMIT}"
   - docker tag "${QUAY_REPO}" "${QUAY_REPO}:${TRAVIS_BRANCH}"
   - docker tag "${QUAY_REPO}" "${QUAY_REPO}:${git_sha}-${TRAVIS_BRANCH}"
-  - docker push "${QUAY_REPO}:${TRAVIS_BRANCH}" && docker push "${QUAY_REPO}:${git_sha}-${TRAVIS_BRANCH}"
+  #only push non-PRs
   - |
-    if [ "${TRAVIS_BRANCH}" = "master" ]; then
-      docker tag "${QUAY_REPO}:${TRAVIS_BRANCH}" "${QUAY_REPO}:latest"
-      docker push "${QUAY_REPO}:latest"
+    if ["${TRAVIS_PULL_REQUEST}" = "false"]; then
+      docker push "${QUAY_REPO}:${TRAVIS_BRANCH}" && docker push "${QUAY_REPO}:${git_sha}-${TRAVIS_BRANCH}"
+      if [ "${TRAVIS_BRANCH}" = "master" ]; then
+        docker tag "${QUAY_REPO}:${TRAVIS_BRANCH}" "${QUAY_REPO}:latest"
+        docker push "${QUAY_REPO}:latest"
+      fi
     fi


### PR DESCRIPTION
Tweak travis to not push docker images to quay for PRs. This prevents master/latest being updated to a created, but not merged, PR. Solves opentargets/platform#452