### PR TITLE
add important note to gene-data-plugin-names part

### DIFF
--- a/mrtarget.data.yml
+++ b/mrtarget.data.yml
@@ -27,7 +27,7 @@ reactome-pathway-relation: https://storage.googleapis.com/open-targets-data-rele
 #uniprot
 uniprot-uri: https://storage.googleapis.com/ot-releases/18.12/annotations/uniprot-20181130.xml.gz
 
-#gene plugins
+#gene plugins (!warning: HGNC,Ensembl,Uniprot should always be first, as they initialize the gene list used in other plugins)
 gene-data-plugin-names: [HGNC,Orthologs,Ensembl,Uniprot,ChEMBL,MousePhenotypes,Hallmarks,CancerBiomarkers,ChemicalProbes,Tractability]
 
 #hgnc gene plugin


### PR DESCRIPTION
PR to improve example .yml file. Maybe it should not be merged here...but I didn't find it in master. Anyway, wherever we end up making an example file, I think this note should be there. Ideally the essential HGNC,Ensembl,Uniprot plugins are just built in the code so that one cannot remove them here or make the mistake of moving them to the back of the list. 