### PR TITLE
Lower pypeln version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,7 @@ petl==1.2.0
 psutil==5.6.1
 PyFunctional==1.2.0
 pyparsing==2.3.1
-pypeln==0.1.8
+pypeln==0.1.6
 pyrsistent==0.14.11
 python-dateutil==2.8.0
 PyYAML==5.1


### PR DESCRIPTION
Version 0.17 and higher of pypeln doens't like functools partial functions. So we are stuck with 0.16 for now.

This is already encoded in the setup.py file but should be consistent with requirements.txt too.