### PR TITLE
make drug internal_compound default to false

### DIFF
--- a/mrtarget/modules/Drug.py
+++ b/mrtarget/modules/Drug.py
@@ -377,6 +377,9 @@ class DrugProcess(object):
             # note, not in chembl
             assert isinstance(mol["internal_compound"], bool), ident
             drug["internal_compound"] = mol["internal_compound"]
+        else:
+            #default to explicitly false 
+            drug["internal_compound"] = False
 
         if "molecule_type" in mol and mol["molecule_type"] is not None:
             #TODO format check


### PR DESCRIPTION
Make the drug internal_compound field default to "False" when not specified in the source e.g. Chembl helps solve https://github.com/opentargets/platform/issues/602