### PR TITLE
add cprofile entrypoint

### DIFF
--- a/scripts/entrypoint.cprofile.sh
+++ b/scripts/entrypoint.cprofile.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+echo "Running mrtarget with parameters $*"
+#python -m mrtarget.CommandLine "$@"
+python -m cProfile -s time mrtarget/CommandLine.py "$@"
+
+exit $!


### PR DESCRIPTION
Add an alternative entrypoint script that uses cProfile to profile the code while it is running.