### PR TITLE
Add drugs info in the GCP script

### DIFF
--- a/scripts/run_on_gcp.sh
+++ b/scripts/run_on_gcp.sh
@@ -190,7 +190,7 @@ gcloud compute ssh $NAME --command 'sudo docker-compose run --rm --entrypoint ma
 #full build!
 #metrics is broken, so dont do it
 gcloud compute ssh $NAME --command "cat > run.sh" <<EOF
-docker-compose run -d --rm --entrypoint make mrtarget -r -R -j -l 16 relationship_data search_data
+docker-compose run -d --rm --entrypoint make mrtarget -r -R -j -l 16 all
 EOF
 gcloud compute ssh $NAME --command "chmod +x run.sh"
 #this will take about 18h to build


### PR DESCRIPTION
Seems to have been missed in https://github.com/opentargets/platform/issues/611.

I chose to run the `all` target. Alternatively we could also run `relationship_data search_data drug_data`. I chose `all` since the addition of a new category of `_data` will just require the addition of this category in the Makefile, which seems preferable, if more opaque to readers of this script.