### PR TITLE
drug_data should depend on base_gene and efo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,7 +118,7 @@ $(LOG_PATH)/out.ddr.log : $(LOG_PATH)/out.as.log
 .PHONY: drug_data
 drug_data: $(LOG_PATH)/out.drg.log
 
-$(LOG_PATH)/out.drg.log : 
+$(LOG_PATH)/out.drg.log : $(LOG_PATH)/out.gen.log $(LOG_PATH)/out.efo.log
 	mkdir -p $(LOG_PATH)
 	$(MRTARGET_CMD) --drg 2>&1 | tee $(LOG_PATH)/out.drg.log
 


### PR DESCRIPTION
Fixes https://github.com/opentargets/platform/issues/659