### PR TITLE
Rename the deprecated _source.include query field

### DIFF
--- a/mrtarget/common/chembl_lookup.py
+++ b/mrtarget/common/chembl_lookup.py
@@ -175,7 +175,7 @@ class ChEMBLLookup(object):
 
         fields = ['target.id','disease.id', 'evidence.target2drug.urls']
         for e in Search().using(es).index(index).query(
-            Match(type="known_drug")).source(include=fields).scan():
+            Match(type="known_drug")).source(includes=fields).scan():
             e = e.to_dict()
             #get information from URLs that we need to extract short ids
             #e.g. https://www.ebi.ac.uk/chembl/compound/inspect/CHEMBL502835

--- a/mrtarget/modules/Association.py
+++ b/mrtarget/modules/Association.py
@@ -306,7 +306,9 @@ def produce_evidence_local_init(es_hosts, es_index_val_right,
 
 def get_evidence_for_target_simple(es, target, index):
     fields = ['target.id', 'private.efo_codes', 'disease.id','scores.association_score','sourceID','id']
-    evidence = Search().using(es).index(index).query(ConstantScore(filter=Q('term', target__id=target))).source(include=fields).params(scroll='4h',size=1000).scan() 
+    evidence = Search().using(es).index(index).query(
+        ConstantScore(filter=Q('term', target__id=target))
+    ).source(includes=fields).params(scroll='4h', size=1000).scan()
     for ev in evidence:
         yield ev.to_dict()
 


### PR DESCRIPTION
This field was renamed to ‘includes’ as of Elasticsearch 5, and the old
usage was causing a Python stack trace and countless (ES-side)
logged deprecation warnings during the `--as` step of the pipeline, and
another logged warning on both ends during the `--sea` step.

See also pull request 1178 of elasticsearch-dsl-py.