### PR TITLE
Ds eva score update

### DIFF
--- a/mrtarget/common/EvidenceString.py
+++ b/mrtarget/common/EvidenceString.py
@@ -607,6 +607,38 @@ class Evidence(JSONSerializable):
                                 self.evidence['variant']['id'], self.evidence['unique_association_fields']['study']))
                             raise
 
+                    # Evidence score for EVA sources evidences are generated based on clinical significance:
+                    elif self.evidence['sourceID'] == 'eva':
+                        clinical_significance_mapping = {
+                            # Less severe:
+                            'association not found': 0.01,  
+                            'benign': 0.01,
+                            'not provided': 0.01,
+                            'likely benign': 0.01,    
+                            
+                            # More severe:
+                            'conflicting interpretations of pathogenicity': 0.3,   
+                            'other': 0.3,
+                            'uncertain significance': 0.3,
+                            
+                            # Moderately severe
+                            'risk factor': 0.5,
+                            'affects': 0.5,
+                            
+                            # Most severe:
+                            'likely pathogenic' : 1,
+                            'association': 1,
+                            'drug response': 1,
+                            'protective': 1,
+                            'pathogenic': 1,
+                        }
+
+                        # the clinical significance is an array, we map each terms to a score value:
+                        clin_sig_scores = [clinical_significance_mapping[x] for x in self.evidence['evidence']['clinical_significance'] if x in clinical_significance_mapping]
+
+                        # chosing the most severe significance value:
+                        score = max(clin_sig_scores)
+                    
                     # Scoring other genetics evidences:
                     else:
                         g2v_score = self.evidence['evidence']['gene2variant']['resource_score']['value']

--- a/mrtarget/common/EvidenceString.py
+++ b/mrtarget/common/EvidenceString.py
@@ -634,10 +634,13 @@ class Evidence(JSONSerializable):
                         }
 
                         # the clinical significance is an array, we map each terms to a score value:
-                        clin_sig_scores = [clinical_significance_mapping[x] for x in self.evidence['evidence']['clinical_significance'] if x in clinical_significance_mapping]
+                        clin_sig_scores = [clinical_significance_mapping[x] if x in clinical_significance_mapping else self.logger.error(f"Cannot map EVA clinical significance: {x}") for x in self.evidence['evidence']['clinical_significance']]
 
                         # chosing the most severe significance value:
-                        score = max(clin_sig_scores)
+                        try:
+                            score = max(clin_sig_scores)
+                        except:
+                            raise ValueError('Some of the EVA clinical significance value is not mapped.')
                     
                     # Scoring other genetics evidences:
                     else:

--- a/mrtarget/common/EvidenceString.py
+++ b/mrtarget/common/EvidenceString.py
@@ -634,7 +634,7 @@ class Evidence(JSONSerializable):
                         }
 
                         # the clinical significance is an array, we map each terms to a score value:
-                        clin_sig_scores = [clinical_significance_mapping[x] if x in clinical_significance_mapping else self.logger.error(f"Cannot map EVA clinical significance: {x}") for x in self.evidence['evidence']['clinical_significance']]
+                        clin_sig_scores = [clinical_significance_mapping[x] if x in clinical_significance_mapping else self.logger.error(f"Cannot map EVA clinical significance: {x}") for x in self.evidence['evidence']['variant2disease']['clinical_significance']]
 
                         # chosing the most severe significance value:
                         try:

--- a/mrtarget/common/EvidenceString.py
+++ b/mrtarget/common/EvidenceString.py
@@ -634,7 +634,7 @@ class Evidence(JSONSerializable):
                         }
 
                         # the clinical significance is an array, we map each terms to a score value:
-                        clin_sig_scores = [clinical_significance_mapping[x] for x in self.evidence['evidence']['clinical_significance'] if x in clinical_significance_mapping]
+                        clin_sig_scores = [clinical_significance_mapping[x] if x in clinical_significance_mapping else self.logger.error(f"Cannot get score for EVA clinical significance: variant: {x}") for x in self.evidence['evidence']['clinical_significance'] ]
 
                         # chosing the most severe significance value:
                         score = max(clin_sig_scores)

--- a/mrtarget/common/EvidenceString.py
+++ b/mrtarget/common/EvidenceString.py
@@ -634,7 +634,7 @@ class Evidence(JSONSerializable):
                         }
 
                         # the clinical significance is an array, we map each terms to a score value:
-                        clin_sig_scores = [clinical_significance_mapping[x] if x in clinical_significance_mapping else self.logger.error(f"Cannot get score for EVA clinical significance: variant: {x}") for x in self.evidence['evidence']['clinical_significance'] ]
+                        clin_sig_scores = [clinical_significance_mapping[x] for x in self.evidence['evidence']['clinical_significance'] if x in clinical_significance_mapping]
 
                         # chosing the most severe significance value:
                         score = max(clin_sig_scores)


### PR DESCRIPTION
* Unlike other sources providing genetic associations, EVA evidence is sourced based on clinical significance. 
* The significance terms -> score mapping is done based on a hardcoded dictionary.
* The **list** of significance values in the evidence string is found under `.evidence.clinical_significance`
* All possible values are mapped to scores, then the highest one is chosen if multiple scores are available.
* The script fails with `ValueError` if an unmapped clinical significance is found (report also written into the error log).